### PR TITLE
Added base-url to docs generation

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -62,6 +62,7 @@ jobs:
           module-name: Disruptive
           format: html
           output: docs
+          base-url: https://vegather.github.io/Disruptive/
 
       - name: Push Back docs/
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Somehow the pathing for the documentation stopped working as it used to (not sure how it worked at all before). End result being all.css not loading at all