### PR TITLE
Renamed “docs” branch to “documentation”

### DIFF
--- a/.github/workflows/swift_gen.yml
+++ b/.github/workflows/swift_gen.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Push Back docs
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          # Pushes the `docs` dir to the `docs` branch
-          branch: docs
+          # Pushes the `docs` dir to the `documentation` branch
+          branch: documentation
           file_pattern: docs/
           commit_message: "CI: Updated Swift documentation"
           commit_user_name: "GitHub Action"


### PR DESCRIPTION
The “git-auto-commit-action” was confused about what was a branch, and what was a directory. This should fix that.

Got this error:
`fatal: 'docs' could be both a local file and a tracking branch.` with error code 128