### PR TITLE
Support for Service Accounts, fixed minor bug, minor docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you want to add it manually to your Swift project, you can add the following 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/vegather/Disruptive.git", from: "0.2.0")
+    .package(url: "https://github.com/vegather/Disruptive.git", from: "0.3.0")
 ]
 ```
 
@@ -215,7 +215,7 @@ stream?.onTemperature = { deviceID, temperatureEvent in
 
 The following is a list of all the available endpoints in the Disruptive Technologies REST API, with a checkmark next to the ones that have been implemented in this Swift library.
 
-Progress: ![Progress](https://progress-bar.dev/28/?scale=54&suffix=%20%2f%2054)
+Progress: ![Progress](https://progress-bar.dev/37/?scale=54&suffix=%20%2f%2054)
 
 - [x] ~~GET /projects/{project}/devices~~
 - [x] ~~POST /projects/{project}/devices:batchUpdate~~
@@ -257,15 +257,15 @@ Progress: ![Progress](https://progress-bar.dev/28/?scale=54&suffix=%20%2f%2054)
 - [x] ~~GET /projects/{project}~~
 - [x] ~~PATCH /projects/{project}~~
 - [x] ~~DELETE /projects/{project}~~
-- [ ] GET /projects/{project}/serviceaccounts
-- [ ] POST /projects/{project}/serviceaccounts
-- [ ] GET /projects/{project}/serviceaccounts/{serviceaccount}
-- [ ] PATCH /projects/{project}/serviceaccounts/{serviceaccount}
-- [ ] DELETE /projects/{project}/serviceaccounts/{serviceaccount}
-- [ ] GET /projects/{project}/serviceaccounts/{serviceaccount}/keys
-- [ ] POST /projects/{project}/serviceaccounts/{serviceaccount}/keys
-- [ ] GET /projects/{project}/serviceaccounts/{serviceaccount}/keys/{key}
-- [ ] DELETE /projects/{project}/serviceaccounts/{serviceaccount}/keys/{key}
+- [x] ~~GET /projects/{project}/serviceaccounts~~
+- [x] ~~POST /projects/{project}/serviceaccounts~~
+- [x] ~~GET /projects/{project}/serviceaccounts/{serviceaccount}~~
+- [x] ~~PATCH /projects/{project}/serviceaccounts/{serviceaccount}~~
+- [x] ~~DELETE /projects/{project}/serviceaccounts/{serviceaccount}~~
+- [x] ~~GET /projects/{project}/serviceaccounts/{serviceaccount}/keys~~
+- [x] ~~POST /projects/{project}/serviceaccounts/{serviceaccount}/keys~~
+- [x] ~~GET /projects/{project}/serviceaccounts/{serviceaccount}/keys/{key}~~
+- [x] ~~DELETE /projects/{project}/serviceaccounts/{serviceaccount}/keys/{key}~~
 
 Emulator
 - [ ] GET /projects/{project}/devices

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fvegather%2FDisruptive%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/vegather/Disruptive)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fvegather%2FDisruptive%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/vegather/Disruptive)
 [![API Docs](https://img.shields.io/badge/API-Documentation-333)](https://vegather.github.io/Disruptive/)
-[![Licence](https://img.shields.io/badge/Licence-MIT-333)](https://github.com/vegather/Disruptive/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/Licence-MIT-333)](https://github.com/vegather/Disruptive/blob/master/LICENSE)
 
 Swift library for accessing data from [Disruptive Technologies](https://disruptive-technologies.com).
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Here's an example of how to authenticate a service account with the OAuth2 flow:
 ```swift
 import Disruptive
 
-let serviceAccount = ServiceAccount(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
-let authenticator = OAuth2Authenticator(account: serviceAccount)
+let credentials = ServiceAccountCredentials(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
+let authenticator = OAuth2Authenticator(credentials: credentials)
 let disruptive = Disruptive(authProvider: authenticator)
 
 // All methods called on the disruptive instance will be authenticated

--- a/Sources/Disruptive/Disruptive.swift
+++ b/Sources/Disruptive/Disruptive.swift
@@ -39,7 +39,7 @@ public struct Disruptive {
     /**
      Initializes a `Disruptive` instance.
      
-     - Parameter authProvider: Used to authenticate against the Disruptive Technologies REST API. It is recommended to pass an `OAuth2ServiceAccount` instance to this parameter.
+     - Parameter authProvider: Used to authenticate against the Disruptive Technologies REST API. It is recommended to pass an `OAuth2Authenticator` instance to this parameter.
      - Parameter baseURL: Optional parameter. The base URL for the REST API. The default value is `Disruptive.defaultBaseURL`.
      */
     public init(authProvider: AuthProvider, baseURL: String = Disruptive.defaultBaseURL) {

--- a/Sources/Disruptive/Helpers/Authentication.swift
+++ b/Sources/Disruptive/Helpers/Authentication.swift
@@ -49,7 +49,7 @@ public struct Auth {
 /**
  Defines the interface required to authenticate the `Disruptive` struct.
  
- Any conforming types needs a mechanism to aquire an access token that
+ Any conforming types needs a mechanism to acquire an access token that
  can be used to authenticate against the Disruptive Technologies' REST API.
  */
 public protocol AuthProvider {
@@ -76,9 +76,9 @@ public protocol AuthProvider {
     /// to `false`.
     func logout(completion: @escaping AuthHandler)
     
-    /// A conforming type should use a mechanism to aquire an access token than
+    /// A conforming type should use a mechanism to acquire an access token than
     /// can be used to authenticate against the Disruptive Technologies' REST API.
-    /// Once that token has been aquired, it should be stored in the `auth` property
+    /// Once that token has been acquired, it should be stored in the `auth` property
     /// along with a relevant expiration date.
     ///
     /// This will be called automatically when necessary as long as `shouldAutoRefreshAccessToken`

--- a/Sources/Disruptive/Helpers/Authentication.swift
+++ b/Sources/Disruptive/Helpers/Authentication.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 /**
- A ServiceAccount is used to authenticate against the Disruptive Technologies API.
+ A set of `ServiceAccountCredentials` is used to authenticate against the Disruptive Technologies API.
  It can be created in [DT Studio](https://studio.disruptive-technologies.com) by clicking
- the `Service Account` tab under `API Integrations` in the side menu.
+ the `Service Account` tab under `API Integrations` in the side menu, and creating a new key.
  */
-public struct ServiceAccount: Codable {
+public struct ServiceAccountCredentials: Codable {
     public let email  : String
     public let key    : String
     public let secret : String
@@ -148,13 +148,13 @@ internal extension AuthProvider {
  
  Example:
  ```
- let serviceAccount = ServiceAccount(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
- let authenticator = BasicAuthAuthenticater(account: serviceAccount)
+ let credentials = ServiceAccountCredentials(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
+ let authenticator = BasicAuthAuthenticator(credentials: credentials)
  let disruptive = Disruptive(authProvider: authenticator)
  ```
  */
 public class BasicAuthAuthenticator: AuthProvider {
-    public let account : ServiceAccount
+    public let credentials : ServiceAccountCredentials
     
     /// The authentication details.
     private(set) public var auth: Auth?
@@ -164,12 +164,12 @@ public class BasicAuthAuthenticator: AuthProvider {
     private(set) public var shouldAutoRefreshAccessToken = true
     
     /**
-     Initializes a `BasicAuthAuthenticator` using a `ServiceAccount`.
+     Initializes a `BasicAuthAuthenticator` using a set of `ServiceAccountCredentials`.
      
-     - Parameter account: The `ServiceAccount` to use for authentication. It can be created in [DT Studio](https://studio.disruptive-technologies.com) by clicking the `Service Account` tab under `API Integrations` in the side menu.
+     - Parameter credentials: The `ServiceAccountCredentials` to use for authentication. It can be created in [DT Studio](https://studio.disruptive-technologies.com) by clicking the `Service Account` tab under `API Integrations` in the side menu.
      */
-    public init(account: ServiceAccount) {
-        self.account = account
+    public init(credentials: ServiceAccountCredentials) {
+        self.credentials = credentials
     }
     
     /// Refreshes the access token, stores it in the `auth` property, and sets
@@ -191,11 +191,11 @@ public class BasicAuthAuthenticator: AuthProvider {
         completion(.success(()))
     }
     
-    /// Used internally to create a new access token from the service account passed in to the initializer.
+    /// Used internally to create a new access token from the service account credentials passed in to the initializer.
     /// This access token is stored in the `auth` property along with an expiration date in the `.distantFuture`.
     public func refreshAccessToken(completion: @escaping AuthHandler) {
         auth = Auth(
-            token: "Basic " + "\(account.key):\(account.secret)".data(using: .utf8)!.base64EncodedString(),
+            token: "Basic " + "\(credentials.key):\(credentials.secret)".data(using: .utf8)!.base64EncodedString(),
             expirationDate: .distantFuture
         )
         completion(.success(()))
@@ -218,15 +218,15 @@ public class BasicAuthAuthenticator: AuthProvider {
  
  Example:
  ```
- let serviceAccount = ServiceAccount(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
- let authenticator = OAuth2Authenticator(account: serviceAccount)
+ let credentials = ServiceAccountCredentials(email: "<EMAIL>", key: "<KEY_ID>", secret: "<SECRET>")
+ let authenticator = OAuth2Authenticator(credentials: credentials)
  let disruptive = Disruptive(authProvider: authenticator)
  ```
  */
 public class OAuth2Authenticator: AuthProvider {
 
     /// The service account used to authenticate against the Disruptive Technologies' REST API.
-    public let account : ServiceAccount
+    public let credentials : ServiceAccountCredentials
     
     /// The authentication endpoint to fetch the access token from.
     public let authURL: String
@@ -241,14 +241,14 @@ public class OAuth2Authenticator: AuthProvider {
     
     
     /**
-     Initializes an `OAuth2Authenticator` using a `ServiceAccount`
+     Initializes an `OAuth2Authenticator` using a set of `ServiceAccountCredentials`.
      
-     - Parameter account: The `ServiceAccount` to use for authentication. It can be created in [DT Studio](https://studio.disruptive-technologies.com) by clicking the `Service Account` tab under `API Integrations` in the side menu.
-     - Parameter authURL: Optional parameter. Used to specify the endpoint to exchange a JWT for an access token. The default value is `Disruptive.defaultAuthURL`
+     - Parameter credentials: The `ServiceAccountCredentials` to use for authentication. It can be created in [DT Studio](https://studio.disruptive-technologies.com) by clicking the `Service Account` tab under `API Integrations` in the side menu.
+     - Parameter authURL: Optional parameter. Used to specify the endpoint to exchange a JWT for an access token. The default value is `Disruptive.defaultAuthURL`.
      */
-    public init(account: ServiceAccount, authURL: String = Disruptive.defaultAuthURL) {
+    public init(credentials: ServiceAccountCredentials, authURL: String = Disruptive.defaultAuthURL) {
         self.authURL = authURL
-        self.account = account
+        self.credentials = credentials
     }
     
     /// Refreshes the access token, stores it in the `auth` property, and sets
@@ -274,8 +274,8 @@ public class OAuth2Authenticator: AuthProvider {
     ///
     /// This flow is described in more detail on the [Developer Website](https://support.disruptive-technologies.com/hc/en-us/articles/360011534099-Authentication).
     public func refreshAccessToken(completion: @escaping (Result<Void, DisruptiveError>) -> ()) {
-        guard let authJWT = JWT.serviceAccount(authURL: authURL, account: account) else {
-            DTLog("Failed to create a JWT from service account: \(account)", isError: true)
+        guard let authJWT = JWT.serviceAccount(authURL: authURL, credentials: credentials) else {
+            DTLog("Failed to create a JWT from service account credentials: \(credentials)", isError: true)
             completion(.failure(.unknownError))
             return
         }

--- a/Sources/Disruptive/Helpers/Authentication.swift
+++ b/Sources/Disruptive/Helpers/Authentication.swift
@@ -60,7 +60,7 @@ public protocol AuthProvider {
     
     /// Indicates whether the auth provider should automatically attempt to
     /// refresh the access token if the local one is expired, or if no local access token is available.
-    /// This is intended to prevent any accidental reauthentications being made
+    /// This is intended to prevent any accidental re-authentications being made
     /// after the client has logged out.
     var shouldAutoRefreshAccessToken: Bool { get }
     
@@ -113,7 +113,7 @@ internal extension AuthProvider {
             completion(.success(authToken))
         } else {
             // The auth provider is either not authenticated, or the auth
-            // token too close to getting expired. Will reauthenticate the auth provider
+            // token too close to getting expired. Will re-authenticate the auth provider
             DTLog("Authenticating the auth provider...")
             refreshAccessToken { result in
                 switch result {

--- a/Sources/Disruptive/Helpers/EventTypes.swift
+++ b/Sources/Disruptive/Helpers/EventTypes.swift
@@ -527,7 +527,13 @@ public struct ConnectionStatusEvent: Decodable, Equatable {
         
         // Extract the other values
         self.connection = try values.decode(Connection.self, forKey: .connection)
-        self.available  = try values.decode([Available].self, forKey: .available)
+        
+        // Extracting the list of `available` network interfaces as the REST API
+        // might occasionally return "OFFLINE" in the `available` array, even
+        // though this is not a valid value. This can happen when sending a
+        // `ConnectionStatusEvent` on an emulated Cloud Connector in Studio.
+        let availableStrings = try values.decode([String].self, forKey: .available)
+        self.available = availableStrings.compactMap { Available(rawValue: $0) }
     }
     
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Disruptive/Helpers/JWT.swift
+++ b/Sources/Disruptive/Helpers/JWT.swift
@@ -12,10 +12,10 @@ import Foundation
 internal struct JWT {
     /// Produces a JWT token that is suitable for a Disruptive service account.
     /// Docs: https://support.disruptive-technologies.com/hc/en-us/articles/360011534099-Authentication
-    internal static func serviceAccount(authURL: String, account: ServiceAccount) -> String? {
+    internal static func serviceAccount(authURL: String, credentials: ServiceAccountCredentials) -> String? {
         let headers = [
             "alg": "HS256",
-            "kid": account.key
+            "kid": credentials.key
         ]
         
         let now = Int(Date().timeIntervalSince1970)
@@ -23,10 +23,10 @@ internal struct JWT {
             "iat": now,
             "exp": now + 3600,
             "aud": authURL,
-            "iss": account.email
+            "iss": credentials.email
         ]
         
-        return jwt(headers: headers, claims: claims, secret: account.secret)
+        return jwt(headers: headers, claims: claims, secret: credentials.secret)
     }
     
     /// Produces a JWT token for a given set of `headers`, `claims`, and a `secret`. No default

--- a/Sources/Disruptive/Resources/DataConnector.swift
+++ b/Sources/Disruptive/Resources/DataConnector.swift
@@ -18,7 +18,7 @@ import Foundation
  */
 public struct DataConnector: Decodable, Equatable {
     
-    /// The unique identifier of the Data Connector. This will be different from the REST API
+    /// The unique identifier of the Data Connector. This will be different from the`name` field in the REST API
     /// in that it is just the identifier without the `projects/*/dataconnectors/` prefix.
     public let identifier: String
     

--- a/Sources/Disruptive/Resources/DataConnector.swift
+++ b/Sources/Disruptive/Resources/DataConnector.swift
@@ -166,7 +166,7 @@ extension Disruptive {
      
      ```
      // Deactivates a Data Connector by only using the `active` parameter
-     updateDataConnector(
+     disruptive.updateDataConnector(
          projectID       : "<PROJECT_ID>",
          dataConnectorID : "<DC_ID>",
          active          : false)
@@ -175,7 +175,7 @@ extension Disruptive {
      }
   
      // Updates the signature secret of a Data Connector, and nothing else
-     updateDataConnector(
+     disruptive.updateDataConnector(
          projectID       : "<PROJECT_ID>",
          dataConnectorID : "<DC_ID>",
          httpPush        : (url: nil, signatureSecret: "NEW_SECRET", headers: nil))
@@ -191,7 +191,7 @@ extension Disruptive {
      - Parameter isActive: The new active status of the Data Connector. Will be ignored if not set (or `nil`). Defaults to `nil`.
      - Parameter eventTypes: The new list of event types the Data Connector will send out. Will be ignored if not set (or `nil`). Defaults to `nil`.
      - Parameter labels: The new labels that will be included for every event pushed to an external service by the Data Connector. Will be ignored if not set (or `nil`). **Note:** if you want the display name of the device to be included in the events to the external service, you need to include the `name` label in this list. The default value of this parameter is `nil`.
-     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the `DataConnector`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the updated `DataConnector`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
      - Parameter result: `Result<DataConnector, DisruptiveError>`
      */
     public func updateDataConnector(

--- a/Sources/Disruptive/Resources/Device.swift
+++ b/Sources/Disruptive/Resources/Device.swift
@@ -15,7 +15,8 @@ import Foundation
  */
 public struct Device: Decodable, Equatable {
     
-    /// The unique identifier of the device. This will be different from the REST API in that it is just the identifier without the `projects/*/devices/` prefix.
+    /// The unique identifier of the device. This will be different from the `name` field in the REST API
+    /// in that it is just the identifier without the `projects/*/devices/` prefix.
     public let identifier: String
     
     /// The display name of the device.

--- a/Sources/Disruptive/Resources/Device.swift
+++ b/Sources/Disruptive/Resources/Device.swift
@@ -248,10 +248,10 @@ extension Disruptive {
 
 extension Device {
     private enum CodingKeys: String, CodingKey {
-        case identifier = "name"
+        case name
         case labels
         case type
-        case reportedEvents = "reported"
+        case reported
     }
     
     public init(from decoder: Decoder) throws {
@@ -259,7 +259,7 @@ extension Device {
         
         // Device resource names are formatted as "projects/b7s3umd0fee000ba5di0/devices/b5rj9ed7rihk942p48og"
         // Setting the identifier to the last component of the resource name
-        let projectResourceName = try values.decode(String.self, forKey: .identifier)
+        let projectResourceName = try values.decode(String.self, forKey: .name)
         let resourceNameComponents = projectResourceName.components(separatedBy: "/")
         guard resourceNameComponents.count == 4 else {
             throw ParseError.identifier(path: projectResourceName)
@@ -274,7 +274,7 @@ extension Device {
         // The name of the device comes in a label (if set)
         self.displayName = self.labels["name", default: ""]
         
-        self.reportedEvents = try values.decode(ReportedEvents.self, forKey: .reportedEvents)
+        self.reportedEvents = try values.decode(ReportedEvents.self, forKey: .reported)
     }
 }
 

--- a/Sources/Disruptive/Resources/Event.swift
+++ b/Sources/Disruptive/Resources/Event.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- Contains a array of events for each type of event for a specific `Device`.  Detailed documentation for each event type can be found on Disruptive Technologies' [developer website](https://support.disruptive-technologies.com/hc/en-us/articles/360012510839-Events).
+ Contains an array of events for each type of event for a specific `Device`.  Detailed documentation for each event type can be found on Disruptive Technologies' [developer website](https://support.disruptive-technologies.com/hc/en-us/articles/360012510839-Events).
  
  Relevant methods for `Events` can be found on the [Disruptive](../Disruptive) struct.
  */

--- a/Sources/Disruptive/Resources/Organization.swift
+++ b/Sources/Disruptive/Resources/Organization.swift
@@ -15,7 +15,8 @@ import Foundation
  */
 public struct Organization: Codable, Equatable {
     
-    /// The unique identifier for the organization. This will be different from the REST API in that it is just the identifier without the `organizations/` prefix.
+    /// The unique identifier for the organization. This will be different from the `name` field in the REST API
+    /// in that it is just the identifier without the `organizations/` prefix.
     public let identifier: String
     
     /// The display name of the organization.

--- a/Sources/Disruptive/Resources/Project.swift
+++ b/Sources/Disruptive/Resources/Project.swift
@@ -15,7 +15,8 @@ import Foundation
  */
 public struct Project: Codable, Equatable {
     
-    /// The unique identifier of the project.
+    /// The unique identifier of the project. This will be different from the `name` field in the REST API
+    /// in that it is just the identifier without the `projects/` prefix.
     public let identifier: String
     
     /// The display name of the project.

--- a/Sources/Disruptive/Resources/ServiceAccount.swift
+++ b/Sources/Disruptive/Resources/ServiceAccount.swift
@@ -1,0 +1,399 @@
+//
+//  ServiceAccount.swift
+//  
+//
+//  Created by Vegard Solheim Theriault on 22/12/2020.
+//
+
+import Foundation
+
+/**
+ All programmatic interaction with the Disruptive Technologies API is done via a logged-in Service Account.
+ 
+ To learn more about Service Accounts, see the [Service Account page on the developer website](https://support.disruptive-technologies.com/hc/en-us/articles/360012295100-Service-Accounts).
+ */
+public struct ServiceAccount: Decodable, Equatable {
+    
+    /// The unique identifier of the Service Account. This will be different from the `name` field in the REST API
+    /// in that it is just the identifier without the `projects/*/serviceaccounts/` prefix.
+    public let identifier: String
+    
+    /// The identifier of the project the Service Account is in.
+    public let projectID: String
+    
+    /// The email of the Service Accounts. Used for authenticating the Service Account.
+    /// Has the format: `<identifier>@<projectID>.serviceaccount.d21s.com`.
+    public let email: String
+    
+    /// The display name of the Service Account.
+    public let displayName: String
+    
+    /// Indicates whether or not the Service Account can be authenticated using HTTP basic auth.
+    /// It is *not* recommended to have this enabled in a production environment.
+    public let basicAuthEnabled: Bool
+    
+    /// The timestamp for when the Service Account was created.
+    public let createTime: Date
+    
+    /// The timestamp for when the Service Account was last updated.
+    public let updateTime: Date
+}
+
+extension Disruptive {
+    
+    /**
+     Gets a list of Service Accounts that are available in a specific project.
+     
+     - Parameter projectID: The identifier of the project to get Service Accounts from.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain an array of `ServiceAccount`s. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<[ServiceAccount], DisruptiveError>`
+     */
+    public func getServiceAccounts(
+        projectID  : String,
+        completion : @escaping (_ result: Result<[ServiceAccount], DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts"
+        let request = Request(method: .get, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request, pagingKey: "serviceAccounts") { completion($0) }
+    }
+    
+    /**
+     Gets a specific Service Account within a project by its identifier.
+     
+     - Parameter projectID: The identifier of the project to get the Service Account from.
+     - Parameter serviceAccountID: The identifier of the Service Account to get within the specified project.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the `ServiceAccount`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<ServiceAccount, DisruptiveError>`
+     */
+    public func getServiceAccount(
+        projectID        : String,
+        serviceAccountID : String,
+        completion       : @escaping (_ result: Result<ServiceAccount, DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)"
+        let request = Request(method: .get, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request) { completion($0) }
+    }
+    
+    /**
+     Creates a new Service Account within a specific project. This Service Account will by default not
+     have access to any resources, it will just have the specified project as its parent.
+     
+     - Parameter projectID: The identifier of the project to create the Service Account in.
+     - Parameter displayName: The display name to give the Service Account.
+     - Parameter basicAuthEnabled: Whether or not the Service Account should be able to be authenticated
+     using HTTP basic auth. This is not recommended in a production environment. The default value is `false`.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the `ServiceAccount` (along with its generated identifier). If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<ServiceAccount, DisruptiveError>`
+     */
+    public func createServiceAccount(
+        projectID        : String,
+        displayName      : String,
+        basicAuthEnabled : Bool = false,
+        completion       : @escaping (_ result: Result<ServiceAccount, DisruptiveError>) -> ())
+    {
+        struct ServiceAccountPayload: Encodable {
+            let displayName     : String
+            let enableBasicAuth : Bool
+        }
+        let payload = ServiceAccountPayload(
+            displayName     : displayName,
+            enableBasicAuth : basicAuthEnabled
+        )
+        
+        do {
+            // Create the request
+            let endpoint = "projects/\(projectID)/serviceaccounts"
+            let request = try Request(method: .post, baseURL: baseURL, endpoint: endpoint, body: payload)
+            
+            // Send the request
+            sendRequest(request) { completion($0) }
+        } catch (let error) {
+            DTLog("Failed to init create service account request with payload \(payload). Error: \(error)", isError: true)
+            completion(.failure(.unknownError))
+        }
+    }
+    
+    /**
+     Updates parameters of a specific Service Account. Only the parameters that are set will be updated, and the remaining will be left unchanged.
+     
+     Examples:
+     
+     ```
+     // Enable basic auth
+     disruptive.updateServiceAccount(
+         projectID        : "<PROJECT_ID>",
+         serviceAccountID : "<SERVICE_ACCOUNT_ID>",
+         basicAuthEnabled : true)
+     { result in
+         ...
+     }
+     
+     // Change the display name
+     disruptive.updateServiceAccount(
+         projectID        : "<PROJECT_ID>",
+         serviceAccountID : "<SERVICE_ACCOUNT_ID>",
+         displayName      : "New Display Name")
+     { result in
+         ...
+     }
+     ```
+     
+     - Parameter projectID: The identifier of the project the Service Account to update is in.
+     - Parameter serviceAccountID: The identifier of the Service Account to update.
+     - Parameter displayName: The new display name to use for the Service Account. Will be ignored if not set (or `nil`). Defaults to `nil`.
+     - Parameter basicAuthEnabled: Enables or disables HTTP basic auth for a Service Account. It is recommended to set this to false in a production environment. Will be ignored if not set (or `nil`). Defaults to `nil`.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the updated `ServiceAccount`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<ServiceAccount, DisruptiveError>`
+     */
+    public func updateServiceAccount(
+        projectID        : String,
+        serviceAccountID : String,
+        displayName      : String? = nil,
+        basicAuthEnabled : Bool?   = nil,
+        completion       : @escaping (_ result: Result<ServiceAccount, DisruptiveError>) -> ())
+    {
+        struct ServiceAccountPatch: Encodable {
+            var displayName: String?
+            var enableBasicAuth: Bool?
+        }
+        
+        // Prepare the payload
+        var patch = ServiceAccountPatch()
+        var updateMask = [String]()
+        
+        if let displayName = displayName {
+            patch.displayName = displayName
+            updateMask.append("displayName")
+        }
+        if let basicAuthEnabled = basicAuthEnabled {
+            patch.enableBasicAuth = basicAuthEnabled
+            updateMask.append("enableBasicAuth")
+        }
+        
+        do {
+            // Create the request
+            let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)"
+            let params = ["update_mask": [updateMask.joined(separator: ",")]]
+            let request = try Request(method: .patch, baseURL: baseURL, endpoint: endpoint, params: params, body: patch)
+            
+            // Send the request
+            sendRequest(request) { completion($0) }
+        } catch (let error) {
+            DTLog("Failed to init updateServiceAccount request with payload: \(patch). Error: \(error)", isError: true)
+            completion(.failure(.unknownError))
+        }
+    }
+    
+    /**
+     Deletes a Service Account.
+     
+     - Parameter projectID: The identifier of the project to delete the Service Account from.
+     - Parameter serviceAccountID: The identifier of the Service Account to delete.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` result case is returned, otherwise a `DisruptiveError` is returned in the `.failure` case.
+     - Parameter result: `Result<Void, DisruptiveError>`
+     */
+    public func deleteServiceAccount(
+        projectID        : String,
+        serviceAccountID : String,
+        completion       : @escaping (_ result: Result<Void, DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)"
+        let request = Request(method: .delete, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request) { completion($0) }
+    }
+    
+    /**
+     Gets a list of keys for a specific Service Account.
+     
+     - Parameter projectID: The identifier of the project the Service Account is in.
+     - Parameter serviceAccountID: The identifier of the Service Account to get keys for.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain an array of `ServiceAccount.Key`s. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<[ServiceAccount.Key], DisruptiveError>`
+     */
+    public func getServiceAccountKeys(
+        projectID        : String,
+        serviceAccountID : String,
+        completion       : @escaping (_ result: Result<[ServiceAccount.Key], DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)/keys"
+        let request = Request(method: .get, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request, pagingKey: "keys") { completion($0) }
+    }
+    
+    /**
+     Gets a single key for a specific Service Account.
+     
+     - Parameter projectID: The identifier of the project the Service Account is in.
+     - Parameter serviceAccountID: The identifier of the Service Account to get a key for.
+     - Parameter keyID: The identifier of the key to get.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the `ServiceAccount.Key`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<ServiceAccount.Key, DisruptiveError>`
+     */
+    public func getServiceAccountKey(
+        projectID        : String,
+        serviceAccountID : String,
+        keyID            : String,
+        completion       : @escaping (_ result: Result<ServiceAccount.Key, DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)/keys/\(keyID)"
+        let request = Request(method: .get, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request) { completion($0) }
+    }
+    
+    /**
+     Creates a new key for a Service Account, and gets both the key and the corresponding secret in return.
+     
+     Note a couple of things:
+     * The secret that is returned can not be retrieved later, so make sure to take a note of it.
+     * A Service Account can have a maximum of 10 keys.
+     
+     - Parameter projectID: The identifier of the project the Service Account is in.
+     - Parameter serviceAccountID: The identifier of the Service Account to create a new key for.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain the `ServiceAccount.KeySecret`. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<ServiceAccount.KeySecret, DisruptiveError>`
+     */
+    public func createServiceAccountKey(
+        projectID        : String,
+        serviceAccountID : String,
+        completion       : @escaping (_ result: Result<ServiceAccount.KeySecret, DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)/keys"
+        let request = Request(method: .post, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request) { completion($0) }
+    }
+    
+    /**
+     Deletes a key for a Service Account.
+     
+     This will prevent the Service Account from being able to authenticate using the deleted key.
+     
+     - Parameter projectID: The identifier of the project the Service Account is in.
+     - Parameter serviceAccountID: The identifier of the Service Account to delete a key for.
+     - Parameter keyID: The identifier of the key to delete.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` result case is returned, otherwise a `DisruptiveError` is returned in the `.failure` case.
+     - Parameter result: `Result<Void, DisruptiveError>`
+
+     */
+    public func deleteServiceAccountKey(
+        projectID        : String,
+        serviceAccountID : String,
+        keyID            : String,
+        completion       : @escaping (_ result: Result<Void, DisruptiveError>) -> ())
+    {
+        // Create the request
+        let endpoint = "projects/\(projectID)/serviceaccounts/\(serviceAccountID)/keys/\(keyID)"
+        let request = Request(method: .delete, baseURL: baseURL, endpoint: endpoint)
+        
+        // Send the request
+        sendRequest(request) { completion($0) }
+    }
+}
+
+
+extension ServiceAccount {
+    
+    /// A key that can be used to authenticate a Service Account.
+    public struct Key: Decodable, Equatable {
+        /// The identifier of the Service Account key.
+        public let identifier: String
+        
+        /// The identifier of the Service Account the key belongs to.
+        public let serviceAccountID: String
+        
+        /// The identifier of the project the Service Account belongs to.
+        public let projectID: String
+        
+        /// The timestamp for when the Service Account key was created.
+        public let createTime: Date
+    }
+    
+    /// A secret along with the corresponding key used to authenticate a Service Account.
+    /// This is the response value for when a new key is created for a Service Account.
+    public struct KeySecret: Decodable, Equatable {
+        /// The key the `secret` corresponds to.
+        public let key: Key
+        
+        /// The secret used to authenticate a Service Account.
+        public let secret: String
+    }
+}
+
+extension ServiceAccount.Key {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case createTime
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        // Service Account key resource names are formatted as
+        // "projects/b7s3umd0fee000ba5di0/serviceaccounts/b5rj9ed7rihk942p48og/keys/bvh86mj24tgg00b2515g"
+        // Setting the identifier to the last component of the resource name
+        let keyResourceName = try container.decode(String.self, forKey: .name)
+        let resourceNameComponents = keyResourceName.components(separatedBy: "/")
+        guard resourceNameComponents.count == 6 else {
+            throw ParseError.identifier(path: keyResourceName)
+        }
+        self.identifier       = resourceNameComponents[5]
+        self.serviceAccountID = resourceNameComponents[3]
+        self.projectID        = resourceNameComponents[1]
+        
+        let timeString = try container.decode(String.self, forKey: .createTime)
+        self.createTime = try Date(iso8601String: timeString)
+    }
+}
+
+extension ServiceAccount {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case email
+        case displayName
+        case enableBasicAuth
+        case createTime
+        case updateTime
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        // Service Account resource names are formatted as
+        // "projects/b7s3umd0fee000ba5di0/serviceaccounts/b5rj9ed7rihk942p48og"
+        // Setting the identifier to the last component of the resource name
+        let saResourceName = try container.decode(String.self, forKey: .name)
+        let resourceNameComponents = saResourceName.components(separatedBy: "/")
+        guard resourceNameComponents.count == 4 else {
+            throw ParseError.identifier(path: saResourceName)
+        }
+        self.projectID  = resourceNameComponents[1]
+        self.identifier = resourceNameComponents[3]
+        
+        self.email            = try container.decode(String.self, forKey: .email)
+        self.displayName      = try container.decode(String.self, forKey: .displayName)
+        self.basicAuthEnabled = try container.decode(Bool.self,   forKey: .enableBasicAuth)
+        
+        let createTimestamp = try container.decode(String.self, forKey: .createTime)
+        let updateTimestamp = try container.decode(String.self, forKey: .updateTime)
+        self.createTime = try Date(iso8601String: createTimestamp)
+        self.updateTime = try Date(iso8601String: updateTimestamp)
+    }
+}

--- a/Tests/DisruptiveTests/DisruptiveTests.swift
+++ b/Tests/DisruptiveTests/DisruptiveTests.swift
@@ -10,8 +10,8 @@ class DisruptiveTests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         Request.defaultSession = URLSession(configuration: configuration)
         
-        let sa = ServiceAccount(email: "", key: "", secret: "")
-        let auth = BasicAuthAuthenticator(account: sa)
+        let creds = ServiceAccountCredentials(email: "", key: "", secret: "")
+        let auth = BasicAuthAuthenticator(credentials: creds)
         disruptive = Disruptive(authProvider: auth)
         Disruptive.loggingEnabled = true
     }

--- a/Tests/DisruptiveTests/Tests/AuthenticationTests.swift
+++ b/Tests/DisruptiveTests/Tests/AuthenticationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 class AuthenticationTests: DisruptiveTests {
     
     func testBasicAuth() {
-        let serviceAccount = ServiceAccount(email: "email", key: "key", secret: "secret")
-        let authenticator = BasicAuthAuthenticator(account: serviceAccount)
+        let creds = ServiceAccountCredentials(email: "email", key: "key", secret: "secret")
+        let authenticator = BasicAuthAuthenticator(credentials: creds)
         
         
         
@@ -81,8 +81,8 @@ class AuthenticationTests: DisruptiveTests {
         }
         """.data(using: .utf8)!
         
-        let serviceAccount = ServiceAccount(email: reqEmail, key: reqKey, secret: "secret")
-        let auth = OAuth2Authenticator(account: serviceAccount)
+        let creds = ServiceAccountCredentials(email: reqEmail, key: reqKey, secret: "secret")
+        let auth = OAuth2Authenticator(credentials: creds)
         
         MockURLProtocol.requestHandler = { request in
             self.assertRequestParams(

--- a/Tests/DisruptiveTests/Tests/AuthenticationTests.swift
+++ b/Tests/DisruptiveTests/Tests/AuthenticationTests.swift
@@ -148,12 +148,7 @@ class AuthenticationTests: DisruptiveTests {
                         XCTFail("Unexpected part: \(subParts[0]), value: \(subParts[1])")
                 }
             }
-            
-            
-            
-            
-            print("RETURNING")
-            
+                        
             return (respPayload, resp, nil)
         }
         

--- a/Tests/DisruptiveTests/Tests/ServiceAccountTests.swift
+++ b/Tests/DisruptiveTests/Tests/ServiceAccountTests.swift
@@ -1,0 +1,556 @@
+//
+//  ServiceAccountTests.swift
+//  
+//
+//  Created by Vegard Solheim Theriault on 24/12/2020.
+//
+
+import XCTest
+@testable import Disruptive
+
+class ServiceAccountTests: DisruptiveTests {
+    
+    func testDecodeServiceAccount() {
+        let saIn = createDummyServiceAccount()
+        let saOut = try! JSONDecoder().decode(ServiceAccount.self, from: createServiceAccountJSON(from: saIn))
+        
+        XCTAssertEqual(saIn, saOut)
+    }
+    
+    func testDecodeServiceAccountKey() {
+        let keyIn = createDummyServiceAccountKey()
+        let keyOut = try! JSONDecoder().decode(ServiceAccount.Key.self, from: createServiceAccountKeyJSON(from: keyIn))
+        
+        XCTAssertEqual(keyIn, keyOut)
+    }
+    
+    func testDecodeServiceAccountKeySecret() {
+        let keySecretIn = createDummyServiceAccountKeySecret()
+        let keySecretOut = try! JSONDecoder().decode(ServiceAccount.KeySecret.self, from: createServiceAccountKeySecretJSON(from: keySecretIn))
+        
+        XCTAssertEqual(keySecretIn, keySecretOut)
+    }
+    
+    func testGetServiceAccounts() {
+        let reqProjectID = "proj1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts")
+        
+        let respServiceAccounts = [createDummyServiceAccount(), createDummyServiceAccount()]
+        let respData = createServiceAccountsJSON(from: respServiceAccounts)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.getServiceAccounts(projectID: reqProjectID) { result in
+            switch result {
+                case .success(let accounts):
+                    XCTAssertEqual(accounts, respServiceAccounts)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testGetServiceAccount() {
+        let reqProjectID = "proj1"
+        let reqSAID = "sa1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSAID)")
+        
+        let respSA = createDummyServiceAccount()
+        let respData = createServiceAccountJSON(from: respSA)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.getServiceAccount(projectID: reqProjectID, serviceAccountID: reqSAID) { result in
+            switch result {
+                case .success(_):
+                    break
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testCreateServiceAccount() {
+        let reqProjectID = "abc"
+        let reqDisplayName = "dummy"
+        let reqBasicAuthEnabled = true
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts")
+        let reqBody = """
+        {
+            "displayName": "\(reqDisplayName)",
+            "enableBasicAuth": \(reqBasicAuthEnabled)
+        }
+        """.data(using: .utf8)!
+        
+        let respSA = createDummyServiceAccount()
+        let respData = createServiceAccountJSON(from: respSA)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "POST",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : reqBody
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.createServiceAccount(projectID: reqProjectID, displayName: reqDisplayName, basicAuthEnabled: reqBasicAuthEnabled) { result in
+            switch result {
+                case .success(let sa):
+                    XCTAssertEqual(sa, respSA)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testUpdateServiceAccountAllParametersSet() {
+        let reqProjectID = "proj1"
+        let reqSaID = "sa1"
+        let reqDisplayName = "disp_name"
+        let reqBasicAuthEnabled = true
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)")
+        let reqBody = """
+        {
+          "displayName": "\(reqDisplayName)",
+          "enableBasicAuth": \(reqBasicAuthEnabled)
+        }
+        """.data(using: .utf8)!
+        
+        
+        let respSA = createDummyServiceAccount()
+        let respData = createServiceAccountJSON(from: respSA)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "PATCH",
+                queryParams   : ["update_mask": ["displayName,enableBasicAuth"]],
+                headers       : [:],
+                url           : reqURL,
+                body          : reqBody
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.updateServiceAccount(
+            projectID        : reqProjectID,
+            serviceAccountID : reqSaID,
+            displayName      : reqDisplayName,
+            basicAuthEnabled : reqBasicAuthEnabled)
+        { result in
+            switch result {
+                case .success(let sa):
+                    XCTAssertEqual(sa, respSA)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testUpdateServiceAccountNoParametersSet() {
+        let reqProjectID = "proj1"
+        let reqSaID = "sa1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)")
+        let reqBody = """
+        { }
+        """.data(using: .utf8)!
+        
+        
+        let respSA = createDummyServiceAccount()
+        let respData = createServiceAccountJSON(from: respSA)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "PATCH",
+                queryParams   : ["update_mask": [""]],
+                headers       : [:],
+                url           : reqURL,
+                body          : reqBody
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.updateServiceAccount(
+            projectID        : reqProjectID,
+            serviceAccountID : reqSaID)
+        { result in
+            switch result {
+                case .success(let sa):
+                    XCTAssertEqual(sa, respSA)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testDeleteServiceAccount() {
+        let reqSaID = "sa1"
+        let reqProjectID = "proj1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)")
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "DELETE",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (nil, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.deleteServiceAccount(projectID: reqProjectID, serviceAccountID: reqSaID) { result in
+            switch result {
+                case .success():
+                    break
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testGetServiceAccountKeys() {
+        let reqProjectID = "proj1"
+        let reqSaID = "sa1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)/keys")
+        
+        let respSaKeys = [createDummyServiceAccountKey(), createDummyServiceAccountKey()]
+        let respData = createServiceAccountKeysJSON(from: respSaKeys)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.getServiceAccountKeys(projectID: reqProjectID, serviceAccountID: reqSaID) { result in
+            switch result {
+                case .success(let keys):
+                    XCTAssertEqual(keys, respSaKeys)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testGetServiceAccountKey() {
+        let reqProjectID = "proj1"
+        let reqSaID = "sa1"
+        let reqKeyID = "key1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)/keys/\(reqKeyID)")
+        
+        let respSaKey = createDummyServiceAccountKey()
+        let respData = createServiceAccountKeyJSON(from: respSaKey)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.getServiceAccountKey(projectID: reqProjectID, serviceAccountID: reqSaID, keyID: reqKeyID) { result in
+            switch result {
+                case .success(_):
+                    break
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testCreateServiceAccountKey() {
+        let reqProjectID = "abc"
+        let reqSaId = "sa1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaId)/keys")
+        
+        let respSaKs = createDummyServiceAccountKeySecret()
+        let respData = createServiceAccountKeySecretJSON(from: respSaKs)
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "POST",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.createServiceAccountKey(projectID: reqProjectID, serviceAccountID: reqSaId) { result in
+            switch result {
+                case .success(let ks):
+                    XCTAssertEqual(ks, respSaKs)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testDeleteServiceAccountKey() {
+        let reqProjectID = "proj1"
+        let reqSaID = "sa1"
+        let reqKeyID = "key1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/serviceaccounts/\(reqSaID)/keys/\(reqKeyID)")
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "DELETE",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (nil, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.deleteServiceAccountKey(projectID: reqProjectID, serviceAccountID: reqSaID, keyID: reqKeyID) { result in
+            switch result {
+                case .success():
+                    break
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}
+
+
+
+// -------------------------------
+// MARK: ServiceAccount Helpers
+// -------------------------------
+
+extension ServiceAccountTests {
+    private func createServiceAccountJSONString(from sa: ServiceAccount) -> String {
+        return """
+            {
+                "name": "projects/\(sa.projectID)/serviceaccounts/\(sa.identifier)",
+                "email": "\(sa.email)",
+                "displayName": "\(sa.displayName)",
+                "enableBasicAuth": \(sa.basicAuthEnabled ? "true" : "false"),
+                "createTime": "\(sa.createTime.iso8601String())",
+                "updateTime": "\(sa.updateTime.iso8601String())"
+            }
+            
+        """
+    }
+    
+    fileprivate func createServiceAccountJSON(from sa: ServiceAccount) -> Data {
+        return createServiceAccountJSONString(from: sa).data(using: .utf8)!
+    }
+    
+    fileprivate func createServiceAccountsJSON(from sas: [ServiceAccount]) -> Data {
+        return """
+        {
+            "serviceAccounts": [
+                \(sas.map({ createServiceAccountJSONString(from: $0) }).joined(separator: ","))
+            ],
+            "nextPageToken": ""
+        }
+        """.data(using: .utf8)!
+    }
+    
+    fileprivate func createDummyServiceAccount() -> ServiceAccount {
+        return ServiceAccount(
+            identifier       : "bpoubfs24sg000b24vd0",
+            projectID        : "bpotd75ufmde03ajo8fa",
+            email            : "bpotd75ufmde03ajo8fa@bpoubfs24sg000b24vd0.serviceaccounts.d21s.com",
+            displayName      : "Test account",
+            basicAuthEnabled : true,
+            createTime       : Date(timeIntervalSince1970: 1608768915),
+            updateTime       : Date(timeIntervalSince1970: 1608768915)
+        )
+    }
+}
+
+
+
+
+// -------------------------------
+// MARK: ServiceAccount.Key Helpers
+// -------------------------------
+
+extension ServiceAccountTests {
+    private func createServiceAccountKeyJSONString(from key: ServiceAccount.Key) -> String {
+        return """
+        {
+            "name": "projects/\(key.projectID)/serviceaccounts/\(key.serviceAccountID)/keys/\(key.identifier)",
+            "id": "\(key.identifier)",
+            "createTime": "\(key.createTime.iso8601String())"
+        }
+        """
+    }
+    
+    fileprivate func createServiceAccountKeyJSON(from key: ServiceAccount.Key) -> Data {
+        return createServiceAccountKeyJSONString(from: key).data(using: .utf8)!
+    }
+    
+    fileprivate func createServiceAccountKeysJSON(from keys: [ServiceAccount.Key]) -> Data {
+        return """
+        {
+            "keys": [
+                \(keys.map({ createServiceAccountKeyJSONString(from: $0) }).joined(separator: ","))
+            ],
+            "nextPageToken": ""
+        }
+        """.data(using: .utf8)!
+    }
+    
+    fileprivate func createDummyServiceAccountKey() -> ServiceAccount.Key {
+        return ServiceAccount.Key(
+            identifier       : "b5rj9ed7rihk942p48og",
+            serviceAccountID : "bpoubfs24sg000b24vd0",
+            projectID        : "bpotd75ufmde03ajo8fa",
+            createTime       : Date(timeIntervalSince1970: 1608768915)
+        )
+    }
+}
+
+
+
+// -------------------------------
+// MARK: ServiceAccount.KeySecret Helpers
+// -------------------------------
+
+extension ServiceAccountTests {
+    private func createServiceAccountKeySecretJSONString(from keySecret: ServiceAccount.KeySecret) -> String {
+        return """
+        {
+            "key": {
+                "name": "projects/\(keySecret.key.projectID)/serviceaccounts/\(keySecret.key.serviceAccountID)/keys/\(keySecret.key.identifier)",
+                "id": "\(keySecret.key.identifier)",
+                "createTime": "\(keySecret.key.createTime.iso8601String())"
+            },
+            "secret": "\(keySecret.secret)"
+        }
+        """
+    }
+    
+    fileprivate func createServiceAccountKeySecretJSON(from keySecret: ServiceAccount.KeySecret) -> Data {
+        return createServiceAccountKeySecretJSONString(from: keySecret).data(using: .utf8)!
+    }
+    
+    fileprivate func createDummyServiceAccountKeySecret() -> ServiceAccount.KeySecret {
+        return ServiceAccount.KeySecret(
+            key: ServiceAccount.Key(
+                identifier       : "b5rj9ed7rihk942p48og",
+                serviceAccountID : "bpoubfs24sg000b24vd0",
+                projectID        : "bpotd75ufmde03ajo8fa",
+                createTime       : Date(timeIntervalSince1970: 1608768915)
+            ),
+            secret: "the_secret_goes_here"
+        )
+    }
+    
+}


### PR DESCRIPTION
* Added full support for Service Accounts (including docs and tests)
* Renamed `ServiceAccount` to `ServiceAccountCredentials` <-- Breaking change!
* Added workaround for edge-case when `ConnectionStatusEvent.available` contains `OFFLINE` (bug on back-end)
* Minor topo fixes, and improvements to docs.