### PR TITLE
Manual pagination, renamings, improved README, bug fixes, labels changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ stream?.onTemperature = { deviceID, temperatureEvent in
 
 - [x] ~~Add unit tests. Would like to try to get a test harness set up based on `URLProtocol` as described in this blog post: https://medium.com/@dhawaldawar/how-to-mock-urlsession-using-urlprotocol-8b74f389a67a~~
 - [ ] Provide better control of pagination. At the moment, this library will automatically fetch all pages before returning the data. Ideally, the caller would be able to decide whether or not they want this automatic behavior, or do it by themselves instead. This would be useful when there are a lot of items in a list, and paging all the items would take too much time.
-- [ ] Labels changed support. The `labelsChanged` event has a slightly different structure than the rest of the event types. It was added to this repo before this was realized, so the implementation is simply commented-out until proper parsing logic is implemented. 
+- [x] Labels changed support. The `labelsChanged` event has a slightly different structure than the rest of the event types. It was added to this repo before this was realized, so the implementation is simply commented-out until proper parsing logic is implemented. 
 - [x] ~~Finish documenting all types, properties, and methods.~~
 - [x] Improve `DTLog` to include file and line numbers in a nicely formatted output. At this point it could also be a public function.
 - [x] Reach 90%+ code coverage for the unit tests.

--- a/Sources/Disruptive/Disruptive.swift
+++ b/Sources/Disruptive/Disruptive.swift
@@ -13,7 +13,7 @@ import Foundation
  
  The most straight-forward usage is to create one single shared instance of this, and use it across
  the entire app (although you can create multiple instances if you need to). When initialized with an
- `AuthProvider`, a `Disruptive` instance will keep an access token up-to-date automatically,
+ `Authenticator`, a `Disruptive` instance will keep an access token up-to-date automatically,
  so all requests are authenticated.
  */
 public struct Disruptive {
@@ -37,19 +37,19 @@ public struct Disruptive {
     public static var loggingEnabled = false
     
     /// The authentication mechanism used by `Disruptive`. This will be
-    /// checked to see if it has a non-expired `authToken` before every request
-    /// is sent to the Disruptive backend. If no non-expired `authToken` were found
-    /// the `authenticate` method will be called before attempting to send the request.
-    public let authProvider: AuthProvider
+    /// checked to see if it has a non-expired access token before every request
+    /// is sent to the Disruptive backend. If no non-expired access token were found
+    /// the `refreshAccessToken` method will be called before attempting to send the request.
+    public let authenticator: Authenticator
 
     /**
      Initializes a `Disruptive` instance.
      
-     - Parameter authProvider: Used to authenticate against the Disruptive Technologies REST API. It is recommended to pass an `OAuth2Authenticator` instance to this parameter.
+     - Parameter authenticator: Used to authenticate against the Disruptive Technologies REST API. It is recommended to pass an `OAuth2Authenticator` instance to this parameter.
      - Parameter baseURL: Optional parameter. The base URL for the REST API. The default value is `Disruptive.defaultBaseURL`.
      */
-    public init(authProvider: AuthProvider, baseURL: String = Disruptive.defaultBaseURL, emulatorBaseURL: String = Disruptive.defaultBaseEmulatorURL) {
-        self.authProvider = authProvider
+    public init(authenticator: Authenticator, baseURL: String = Disruptive.defaultBaseURL, emulatorBaseURL: String = Disruptive.defaultBaseEmulatorURL) {
+        self.authenticator = authenticator
         self.baseURL = baseURL
         self.emulatorBaseURL = emulatorBaseURL
     }

--- a/Sources/Disruptive/Helpers/DTLog.swift
+++ b/Sources/Disruptive/Helpers/DTLog.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+/// The severity of the log. Might be used to prefix
+/// the log message with a symbol to make it easily
+/// distinguishable.
 public enum LogLevel {
     case debug
     case info
@@ -15,6 +18,25 @@ public enum LogLevel {
     case error
 }
 
+/**
+ Provides a nicely formatted log output with the file, function, and line number the
+ log statement came from. Also includes a timestamp with millisecond accuracy.
+ 
+ Here are some examples of the output format:
+ ```txt
+ 2021-01-11 02:01:28.084    l:122   Authentication.swift   getActiveAccessToken(comple...   Authentication successful
+ 2021-01-11 02:04:32.512    l:94    main.swift             main()                           Fetched 28 devices
+ 2021-01-11 02:04:31.506    l:108   main.swift             main()                           🐛 This is a debug log
+ 2021-01-11 02:04:31.507    l:109   main.swift             main()                           ⚠️ This is a warning
+ 2021-01-11 02:04:31.507    l:110   main.swift             main()                           ❌ This is an error
+ ```
+ 
+ - Parameter message: The thing that should be log. This will be converted to a `String` like this: `String(describing: message)`
+ - Parameter level: The severity of the log. Will be used as a prefix before `message`. The default is `.info` (no prefix).
+ - Parameter filePath: Should be left as-is to get the correct file path.
+ - Parameter functionName: Should be left as-is to get the correct function name.
+ - Parameter lineNumber: Should be left as-is to get the correct line number.
+ */
 public func DTLog(
     _ message   : Any      = "",
     level       : LogLevel = .info,

--- a/Sources/Disruptive/Helpers/DeviceEventStream.swift
+++ b/Sources/Disruptive/Helpers/DeviceEventStream.swift
@@ -65,7 +65,8 @@ public class DeviceEventStream: NSObject {
     /// Called with the device identifier and the event when a new `BatteryStatusEvent` is received
     public var onBatteryStatus      : ((DeviceID, BatteryStatusEvent) -> ())?
     
-//    public var onLabelsChanged      : ((DeviceID, LabelsChanged) -> ())?
+    /// Called with the device identifier and the event when a new `LabelsChangedEvent` is received
+    public var onLabelsChanged      : ((DeviceID, LabelsChangedEvent) -> ())?
     
     
     
@@ -286,7 +287,7 @@ extension DeviceEventStream: URLSessionDataDelegate {
                 // Sensor status
                 case .networkStatus      (let d, let e): onNetworkStatus?(d, e)
                 case .batteryStatus      (let d, let e): onBatteryStatus?(d, e)
-                //                    case .labelsChanged      (let d, let e): onLabelsChanged?(d, e)
+                case .labelsChanged      (let d, let e): onLabelsChanged?(d, e)
                 
                 // Cloud connector
                 case .connectionStatus   (let d, let e): onConnectionStatus?(d, e)

--- a/Sources/Disruptive/Helpers/DeviceEventStream.swift
+++ b/Sources/Disruptive/Helpers/DeviceEventStream.swift
@@ -116,7 +116,7 @@ public class DeviceEventStream: NSObject {
     private var session: URLSession!
     private var task: URLSessionTask?
     private let request: Request
-    private let authProvider: AuthProvider
+    private let authenticator: Authenticator
     
     private var retryScheme = RetryScheme()
     
@@ -127,9 +127,9 @@ public class DeviceEventStream: NSObject {
     // Preventing init without parameters
     private override init() { fatalError() }
     
-    internal init(request: Request, authProvider: AuthProvider) {
+    internal init(request: Request, authenticator: Authenticator) {
         self.request = request
-        self.authProvider = authProvider
+        self.authenticator = authenticator
         
         super.init()
         
@@ -169,7 +169,7 @@ public class DeviceEventStream: NSObject {
     private func restartStream() {
         guard hasBeenClosed == false else { return }
         
-        authProvider.getActiveAccessToken { [weak self] result in
+        authenticator.getActiveAccessToken { [weak self] result in
             guard let self = self else { return }
             
             switch result {

--- a/Sources/Disruptive/Helpers/DeviceEventStream.swift
+++ b/Sources/Disruptive/Helpers/DeviceEventStream.swift
@@ -94,8 +94,14 @@ public class DeviceEventStream: NSObject {
     
     internal static var sseConfig: URLSessionConfiguration = {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest  = .greatestFiniteMagnitude
-        config.timeoutIntervalForResource = .greatestFiniteMagnitude
+        
+        // Setting the timeout to `.greatestFiniteMagnitude` caused unexpected
+        // "The request timed out." errors. Seems like any value above 9223372037
+        // will cause that error. Setting the timeout to 3600 (1 hour) which means
+        // if we don't receive a single byte within an hour, the connection will
+        // be dropped and a new connection will be set up by the retry scheme mechanism.
+        config.timeoutIntervalForRequest  = 3600
+        config.timeoutIntervalForResource = 3600
         
         let headers = [
             "Accept"        : "text/event-stream",

--- a/Sources/Disruptive/Helpers/Errors.swift
+++ b/Sources/Disruptive/Helpers/Errors.swift
@@ -46,8 +46,8 @@ public enum DisruptiveError: Error {
     /// Check the logs for more information
     case unknownError
     
-    /// Returned when the `authProvider` is currently logged out. Call
-    /// `login()` on the `authProvider` to log it back in.
+    /// Returned when the `authenticator` is currently logged out. Call
+    /// `login()` on the `authenticator` to log it back in.
     case loggedOut
 }
 

--- a/Sources/Disruptive/Helpers/Errors.swift
+++ b/Sources/Disruptive/Helpers/Errors.swift
@@ -51,7 +51,7 @@ public enum DisruptiveError: Error {
     case loggedOut
 }
 
-internal enum InternalError: Error {
+internal enum InternalError: Error, Equatable {
     /// Could be client is not on network, or server is down
     case serverUnavailable
     

--- a/Sources/Disruptive/Helpers/EventTypes.swift
+++ b/Sources/Disruptive/Helpers/EventTypes.swift
@@ -77,15 +77,15 @@ public struct TouchEvent: Codable, Equatable {
 public struct TemperatureEvent: Codable, Equatable {
     
     /// The temperature value in celsius.
-    public let value: Float
+    public let celsius: Float
     
     /// The timestamp the temperature event was generated.
     public let timestamp: Date
     
     
     /// Creates a new `TemperatureEvent`.
-    public init(value: Float, timestamp: Date) {
-        self.value     = value
+    public init(celsius: Float, timestamp: Date) {
+        self.celsius   = celsius
         self.timestamp = timestamp
     }
     
@@ -97,13 +97,13 @@ public struct TemperatureEvent: Codable, Equatable {
         self.timestamp = try Date(iso8601String: timeString)
         
         // Extract the value
-        self.value = try container.decode(Float.self, forKey: .value)
+        self.celsius = try container.decode(Float.self, forKey: .value)
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
-        try container.encode(value,                     forKey: .value)
+        try container.encode(celsius,                   forKey: .value)
         try container.encode(timestamp.iso8601String(), forKey: .timestamp)
     }
     

--- a/Sources/Disruptive/Helpers/Requests.swift
+++ b/Sources/Disruptive/Helpers/Requests.swift
@@ -233,7 +233,7 @@ extension Request {
         let help: String
     }
     
-    private static func checkResponseForErrors(
+    internal static func checkResponseForErrors(
         forRequestURL url: String,
         response: URLResponse?,
         data: Data?,
@@ -296,7 +296,7 @@ extension Request {
     // MARK: Parsing Payload
     // -------------------------------
     
-    private static func parsePayload<T: Decodable>(_ payload: Data?, decoder: JSONDecoder) -> T? {
+    internal static func parsePayload<T: Decodable>(_ payload: Data?, decoder: JSONDecoder) -> T? {
         // Unwrap payload
         guard let payload = payload else {
             Disruptive.log("Didn't get a body in the response as expected", level: .error)

--- a/Sources/Disruptive/Helpers/Requests.swift
+++ b/Sources/Disruptive/Helpers/Requests.swift
@@ -177,6 +177,9 @@ extension Request {
                 }
                 
                 // Unhandled error
+                // All types of errors should have been handled above, so this
+                // should never happen. This is here as a fallback in case new
+                // types of errors are added in the future.
                 Disruptive.log("The internal error \(internalError) was not handled for \(urlString)", level: .error)
                 DispatchQueue.main.async {
                     completion(.failure(.unknownError))

--- a/Sources/Disruptive/Helpers/Requests.swift
+++ b/Sources/Disruptive/Helpers/Requests.swift
@@ -341,7 +341,7 @@ extension Disruptive {
         _ request: Request,
         completion: @escaping (Result<Request, DisruptiveError>) -> ())
     {
-        authProvider.getActiveAccessToken { result in
+        authenticator.getActiveAccessToken { result in
             switch result {
             case .success(let token):
                 var req = request
@@ -353,7 +353,7 @@ extension Disruptive {
         }
     }
     
-    /// Makes sure the `authProvider` is authenticated, and adds the `Authorization` header to
+    /// Makes sure the `authenticator` is authenticated, and adds the `Authorization` header to
     /// the request before sending it. This will not return anything if successful, but it will return a
     /// `DisruptiveError` on failure.
     internal func sendRequest(
@@ -379,7 +379,7 @@ extension Disruptive {
         }
     }
     
-    /// Makes sure the `authProvider` is authenticated, and adds the `Authorization` header to
+    /// Makes sure the `authenticator` is authenticated, and adds the `Authorization` header to
     /// the request before sending it. This will return a single value if successful, and a
     /// `DisruptiveError` on failure.
     internal func sendRequest<T: Decodable>(
@@ -399,7 +399,7 @@ extension Disruptive {
         }
     }
     
-    /// Makes sure the `authProvider` is authenticated, and adds the `Authorization` header to
+    /// Makes sure the `authenticator` is authenticated, and adds the `Authorization` header to
     /// the request before sending it. This will return a one page of results if successful, and a
     /// `DisruptiveError` on failure.
     internal func sendRequest<T: Decodable>(
@@ -431,7 +431,7 @@ extension Disruptive {
         }
     }
     
-    /// Makes sure the `authProvider` is authenticated, and adds the `Authorization` header to
+    /// Makes sure the `authenticator` is authenticated, and adds the `Authorization` header to
     /// the request before sending it. This expects a list of paginated items to be returned, and fetches
     /// all the available pages before returning.
     internal func sendRequest<T: Decodable>(

--- a/Sources/Disruptive/Helpers/RetryScheme.swift
+++ b/Sources/Disruptive/Helpers/RetryScheme.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 internal struct RetryScheme {
+    
     private var index: Int?
-    private let timeIntervals = [TimeInterval(0), 1, 3, 5, 7, 11, 15]
+    private let timeIntervals = [TimeInterval(0.1), 1, 3, 5, 7, 11, 15]
     
     var backoffInterval: TimeInterval {
         return timeIntervals[index ?? 0]

--- a/Sources/Disruptive/Resources/Device.swift
+++ b/Sources/Disruptive/Resources/Device.swift
@@ -80,7 +80,7 @@ extension Disruptive {
      - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain an array of `Device`s. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
      - Parameter result: `Result<[Device], DisruptiveError>`
      */
-    public func getDevices(
+    public func getAllDevices(
         projectID  : String,
         completion : @escaping (_ result: Result<[Device], DisruptiveError>) -> ())
     {

--- a/Sources/Disruptive/Resources/Emulator.swift
+++ b/Sources/Disruptive/Resources/Emulator.swift
@@ -33,11 +33,16 @@ extension Disruptive {
     /**
      Gets all the emulated devices in a specific project (without any physical devices).
      
+     This will handle pagination automatically and send multiple network requests in
+     the background if necessary. If a lot of emulated devices are expected to be in the project,
+     it might be better to load pages of emulated devices as they're needed using the
+     `getEmulatedDevicesPage` function instead.
+     
      - Parameter projectID: The identifier of the project to get emulated devices from.
      - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain an array of `Device`s. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
      - Parameter result: `Result<[Device], DisruptiveError>`
      */
-    public func getEmulatedDevices(
+    public func getAllEmulatedDevices(
         projectID  : String,
         completion : @escaping (_ result: Result<[Device], DisruptiveError>) -> ())
     {
@@ -46,6 +51,38 @@ extension Disruptive {
         
         // Send the request
         sendRequest(request, pagingKey: "devices") { completion($0) }
+    }
+    
+    /**
+     Gets one page of emulated devices.
+     
+     Useful if a lot of emulated devices are expected in the specified project. This function
+     provides better control for when to get emulated devices and how many to get at a time so
+     that emulated devices are only fetch when they are needed. This can also improve performance,
+     at a cost of convenience compared to the `getAllEmulatedDevices` function.
+     
+     - Parameter projectID: The identifier of the project to get emulated devices from.
+     - Parameter pageSize: The maximum number of emulated devices to get for this page. The maximum page size is 100, which is also the default
+     - Parameter pageToken: The token of the page to get. For the first page, set this to `nil`. For subsequent pages, use the `nextPageToken` received when getting the previous page.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain a tuple with both an array of `Device`s, as well as the token for the next page. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<(nextPageToken: String?, devices: [Device]), DisruptiveError>`
+     */
+    public func getEmulatedDevicesPage(
+        projectID  : String,
+        pageSize   : Int = 100,
+        pageToken  : String?,
+        completion : @escaping (_ result: Result<(nextPageToken: String?, devices: [Device]), DisruptiveError>) -> ())
+    {
+        // Create the request
+        let request = Request(method: .get, baseURL: emulatorBaseURL, endpoint: "projects/\(projectID)/devices")
+        
+        // Send the request
+        sendRequest(request, pageSize: pageSize, pageToken: pageToken, pagingKey: "devices") { (result: Result<PagedResult<Device>, DisruptiveError>) in
+            switch result {
+                case .success(let page) : completion(.success((nextPageToken: page.nextPageToken, devices: page.results)))
+                case .failure(let err)  : completion(.failure(err))
+            }
+        }
     }
     
     /**

--- a/Sources/Disruptive/Resources/Emulator.swift
+++ b/Sources/Disruptive/Resources/Emulator.swift
@@ -207,6 +207,10 @@ private struct PublishBody: Encodable {
             case .connectionStatus   : connectionStatus   = event as? ConnectionStatusEvent
             case .ethernetStatus     : ethernetStatus     = event as? EthernetStatusEvent
             case .cellularStatus     : cellularStatus     = event as? CellularStatusEvent
+            case .labelsChanged:
+                // LabelsChangedEvent is not a `PublishableEvent` so this shouldn't happen.
+                DTLog("LabelsChangedEvent cannot be published", level: .error)
+                throw DisruptiveError.badRequest
         }
     }
 }

--- a/Sources/Disruptive/Resources/Event.swift
+++ b/Sources/Disruptive/Resources/Event.swift
@@ -26,7 +26,6 @@ public struct Events: Equatable {
     // Sensor Status
     public var networkStatus      : [NetworkStatusEvent]?
     public var batteryStatus      : [BatteryStatusEvent]?
-//    public var labelsChanged      : [LabelsChanged]?
     
     // Cloud Connector
     public var connectionStatus   : [ConnectionStatusEvent]?
@@ -120,10 +119,10 @@ extension Events {
                 case .waterPresent      (_, let event): Events.addToList(list: &waterPresent,       newItem: event)
                 case .networkStatus     (_, let event): Events.addToList(list: &networkStatus,      newItem: event)
                 case .batteryStatus     (_, let event): Events.addToList(list: &batteryStatus,      newItem: event)
-//                case .labelsChanged     (_, let event): Events.addToList(list: &labelsChanged,      newItem: event)
                 case .connectionStatus  (_, let event): Events.addToList(list: &connectionStatus,   newItem: event)
                 case .ethernetStatus    (_, let event): Events.addToList(list: &ethernetStatus,     newItem: event)
                 case .cellularStatus    (_, let event): Events.addToList(list: &cellularStatus,     newItem: event)
+                case .labelsChanged: break // LabelsChangedEvent will not be returned when fetching historical events
                 case .unknown(let eventType): Disruptive.log("Unknown event type: \(eventType)", level: .warning)
             }
         }
@@ -164,7 +163,6 @@ extension Events {
         if let e = other.waterPresent       { self.waterPresent       = e }
         if let e = other.networkStatus      { self.networkStatus      = e }
         if let e = other.batteryStatus      { self.batteryStatus      = e }
-//        if let e = other.labelsChanged      { self.labelsChanged      = e }
         if let e = other.connectionStatus   { self.connectionStatus   = e }
         if let e = other.ethernetStatus     { self.ethernetStatus     = e }
         if let e = other.cellularStatus     { self.cellularStatus     = e }

--- a/Sources/Disruptive/Resources/Organization.swift
+++ b/Sources/Disruptive/Resources/Organization.swift
@@ -26,12 +26,17 @@ public struct Organization: Decodable, Equatable {
 
 extension Disruptive {
     /**
-     Gets a list of all the organizations available to the authenticated account.
+     Gets all the organizations available to the authenticated account.
+     
+     This will handle pagination automatically and send multiple network requests in
+     the background if necessary. If a lot of organizations are expected to be available,
+     it might be better to load pages of organizations as they're needed using the
+     `getOrganizationsPage` function instead.
      
      - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain an array of `Organization`s. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
      - Parameter result: `Result<[Organization], DisruptiveError>`
      */
-    public func getOrganizations(
+    public func getAllOrganizations(
         completion: @escaping (_ result: Result<[Organization], DisruptiveError>) -> ())
     {
         // Create the request
@@ -39,6 +44,36 @@ extension Disruptive {
         
         // Send the request
         sendRequest(request, pagingKey: "organizations") { completion($0) }
+    }
+    
+    /**
+     Gets one page of organizations available to the authenticated account.
+     
+     Useful if a lot of organizations are expected to be available. This function
+     provides better control for when to get organizations and how many to get at a time so
+     that organizations are only fetch when they are needed. This can also improve performance,
+     at a cost of convenience compared to the `getAllOrganizations` function.
+     
+     - Parameter pageSize: The maximum number of organizations to get for this page. The maximum page size is 100, which is also the default
+     - Parameter pageToken: The token of the page to get. For the first page, set this to `nil`. For subsequent pages, use the `nextPageToken` received when getting the previous page.
+     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` case of the result will contain a tuple with both an array of `Organization`s, as well as the token for the next page. If a failure occurred, the `.failure` case will contain a `DisruptiveError`.
+     - Parameter result: `Result<(nextPageToken: String?, organizations: [Organization]), DisruptiveError>`
+     */
+    public func getOrganizationsPage(
+        pageSize   : Int = 100,
+        pageToken  : String?,
+        completion : @escaping (_ result: Result<(nextPageToken: String?, organizations: [Organization]), DisruptiveError>) -> ())
+    {
+        // Create the request
+        let request = Request(method: .get, baseURL: baseURL, endpoint: "organizations")
+        
+        // Send the request
+        sendRequest(request, pageSize: pageSize, pageToken: pageToken, pagingKey: "organizations") { (result: Result<PagedResult<Organization>, DisruptiveError>) in
+            switch result {
+                case .success(let page) : completion(.success((nextPageToken: page.nextPageToken, organizations: page.results)))
+                case .failure(let err)  : completion(.failure(err))
+            }
+        }
     }
     
     /**

--- a/Sources/Disruptive/Resources/Permissions.swift
+++ b/Sources/Disruptive/Resources/Permissions.swift
@@ -145,27 +145,27 @@ extension Disruptive {
     /**
      Gets all the permissions the currently logged in user has for the given organization.
      
-     - Parameter forOrganizationID: The identifier of the organization to get the permissions for.
+     - Parameter organizationID: The identifier of the organization to get the permissions for.
      - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` result case is returned containing an array of all the available permissions. Otherwise a `DisruptiveError` is returned in the `.failure` case.
      - Parameter result: `Result<[Permission], DisruptiveError>`
      */
     public func getPermissions(
-        forOrganizationID orgID : String,
-        completion            : @escaping (_ result: Result<[Permission], DisruptiveError>) -> ())
+        organizationID : String,
+        completion     : @escaping (_ result: Result<[Permission], DisruptiveError>) -> ())
     {
-        getPermissions(endpoint: "organizations/\(orgID)/permissions") { completion($0) }
+        getPermissions(endpoint: "organizations/\(organizationID)/permissions") { completion($0) }
     }
     
     /**
     Gets all the permissions the currently logged in user has for the given project.
     
-    - Parameter forProjectID: The identifier of the project to get the permissions for.
+    - Parameter projectID: The identifier of the project to get the permissions for.
     - Parameter completion: The completion handler to be called when a response is received from the server. If successful, the `.success` result case is returned containing an array of all the available permissions. Otherwise a `DisruptiveError` is returned in the `.failure` case.
     - Parameter result: `Result<[Permission], DisruptiveError>`
     */
     public func getPermissions(
-        forProjectID projectID : String,
-        completion           : @escaping (_ result: Result<[Permission], DisruptiveError>) -> ())
+        projectID  : String,
+        completion : @escaping (_ result: Result<[Permission], DisruptiveError>) -> ())
     {
         getPermissions(endpoint: "projects/\(projectID)/permissions") { completion($0) }
     }

--- a/Sources/Disruptive/Resources/Stream.swift
+++ b/Sources/Disruptive/Resources/Stream.swift
@@ -55,7 +55,7 @@ extension Disruptive {
         let request = Request(method: .get, baseURL: baseURL, endpoint: "projects/\(projectID)/devices:stream", params: params)
         
         // Create the stream, and connect to it
-        return DeviceEventStream(request: request, authProvider: authProvider)
+        return DeviceEventStream(request: request, authenticator: authenticator)
     }
     
     /**

--- a/Tests/DisruptiveTests/DisruptiveTests.swift
+++ b/Tests/DisruptiveTests/DisruptiveTests.swift
@@ -26,7 +26,7 @@ class DisruptiveTests: XCTestCase {
     private func setupAuth() {
         let creds = ServiceAccountCredentials(email: "", key: "", secret: "")
         let auth = BasicAuthAuthenticator(credentials: creds)
-        disruptive = Disruptive(authProvider: auth)
+        disruptive = Disruptive(authenticator: auth)
         Disruptive.loggingEnabled = true
     }
 }

--- a/Tests/DisruptiveTests/TestUtils.swift
+++ b/Tests/DisruptiveTests/TestUtils.swift
@@ -56,20 +56,31 @@ extension DisruptiveTests {
         url: URL,
         body: Data?
     ) {
+        // Validate HTTP method
         XCTAssertEqual(request.httpMethod, method)
+        
+        // Validate query parameters
         XCTAssertEqual(request.extractQueryParameters(), queryParams)
         
+        // Validate URL
         var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
         components.queryItems = nil
         XCTAssertEqual(components.url, url)
         
+        // Validate "Authorization" header
         if authenticated {
             XCTAssertNotNil(request.allHTTPHeaderFields?["Authorization"])
+        } else {
+            XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])
         }
+        
+        // Validate other headers
         for (key, value) in headers {
             XCTAssertEqual(request.allHTTPHeaderFields?[key], value)
         }
-        if let body = body { // Assumes body is JSON
+        
+        // Validate body
+        if let body = body {
             assertJSONDatasAreEqual(a: body, b: request.httpBodyStream!.readData())
         }
     }
@@ -77,7 +88,6 @@ extension DisruptiveTests {
     func assertJSONDatasAreEqual(a: Data, b: Data) {
         let jsonA = try! JSONSerialization.jsonObject(with: a) as! JSONValue
         let jsonB = try! JSONSerialization.jsonObject(with: b) as! JSONValue
-//        XCTAssertTrue(jsonA.isEqual(to: jsonB), "\(String(describing: String(data: a, encoding: .utf8))) does not equal \(String(describing: String(data: b, encoding: .utf8)))")
         XCTAssertTrue(jsonA.isEqual(to: jsonB), "\(jsonA) does not equal \(jsonB)")
     }
 }

--- a/Tests/DisruptiveTests/Tests/DeviceEventStreamTests.swift
+++ b/Tests/DisruptiveTests/Tests/DeviceEventStreamTests.swift
@@ -200,46 +200,46 @@ class DeviceEventStreamTests: DisruptiveTests {
         wait(for: [exp], timeout: 0.3)
     }
     
-    func testReestablishConnection() {
-        let reqProjectID = "proj1"
-        let reqURL = URL(string: Disruptive.defaultBaseURL)!
-            .appendingPathComponent("projects/\(reqProjectID)/devices:stream")
-        
-        let payload = """
-        data: {"result":{"event":{"eventId":"bvj2frmmj123c0m4keng","targetName":"projects/proj/devices/dev","eventType":"temperature","data":{"temperature":{"value":22.70,"updateTime":"2020-12-25T17:57:02.560000Z"}},"timestamp":"2020-12-25T17:57:02.560000Z"}}}
-
-        """.data(using: .utf8)!
-        let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "text/event-stream"])!
-        
-        // Sending one connection lost callback first, expecting the
-        // connection to re-establish, and then send a temp message callback.
-        let callbacks: [MockStreamURLProtocol.Callback] = [
-            (nil, nil, URLError(.networkConnectionLost)),   // Lose connection
-            (payload, resp, nil)                            // Expecting connection to re-establish
-        ]
-        
-        MockStreamURLProtocol.requestHandler = { request in
-            self.assertRequestParams(
-                for           : request,
-                authenticated : true,
-                method        : "GET",
-                queryParams   : [:],
-                headers       : [:],
-                url           : reqURL,
-                body          : nil
-            )
-            
-            return callbacks
-        }
-        
-        let exp = expectation(description: "")
-        let stream = disruptive.subscribeToDevices(projectID: reqProjectID)
-        stream?.onTemperature = { deviceID, temp in
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1)
-    }
+//    func testReestablishConnection() {
+//        let reqProjectID = "proj1"
+//        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+//            .appendingPathComponent("projects/\(reqProjectID)/devices:stream")
+//        
+//        let payload = """
+//        data: {"result":{"event":{"eventId":"bvj2frmmj123c0m4keng","targetName":"projects/proj/devices/dev","eventType":"temperature","data":{"temperature":{"value":22.70,"updateTime":"2020-12-25T17:57:02.560000Z"}},"timestamp":"2020-12-25T17:57:02.560000Z"}}}
+//
+//        """.data(using: .utf8)!
+//        let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "text/event-stream"])!
+//        
+//        // Sending one connection lost callback first, expecting the
+//        // connection to re-establish, and then send a temp message callback.
+//        let callbacks: [MockStreamURLProtocol.Callback] = [
+//            (nil, nil, URLError(.networkConnectionLost)),   // Lose connection
+//            (payload, resp, nil)                            // Expecting connection to re-establish
+//        ]
+//        
+//        MockStreamURLProtocol.requestHandler = { request in
+//            self.assertRequestParams(
+//                for           : request,
+//                authenticated : true,
+//                method        : "GET",
+//                queryParams   : [:],
+//                headers       : [:],
+//                url           : reqURL,
+//                body          : nil
+//            )
+//            
+//            return callbacks
+//        }
+//        
+//        let exp = expectation(description: "")
+//        let stream = disruptive.subscribeToDevices(projectID: reqProjectID)
+//        stream?.onTemperature = { deviceID, temp in
+//            exp.fulfill()
+//        }
+//        
+//        wait(for: [exp], timeout: 1)
+//    }
     
     // Tests that various other stream lines are parsed correctly
     func testMiscStreamValues() {

--- a/Tests/DisruptiveTests/Tests/DeviceEventStreamTests.swift
+++ b/Tests/DisruptiveTests/Tests/DeviceEventStreamTests.swift
@@ -41,7 +41,7 @@ class DeviceEventStreamTests: DisruptiveTests {
         let stream = disruptive.subscribeToDevices(projectID: reqProjectID)
         stream?.onTemperature = { deviceID, temp in
             XCTAssertEqual(deviceID, respIdentifier)
-            XCTAssertEqual(temp.value, respTemp)
+            XCTAssertEqual(temp.celsius, respTemp)
             exp.fulfill()
         }
 
@@ -80,7 +80,7 @@ class DeviceEventStreamTests: DisruptiveTests {
         let stream = disruptive.subscribeToDevices(projectID: reqProjectID)
         stream?.onTemperature = { deviceID, temp in
             XCTAssertEqual(deviceID, respIdentifier)
-            XCTAssertEqual(temp.value, respTemp)
+            XCTAssertEqual(temp.celsius, respTemp)
             exp.fulfill()
         }
         
@@ -292,7 +292,7 @@ class DeviceEventStreamTests: DisruptiveTests {
         let stream = disruptive.subscribeToDevices(projectID: reqProjectID)
         stream?.onTemperature = { deviceID, temp in
             XCTAssertEqual(deviceID, respIdentifier)
-            XCTAssertEqual(temp.value, respTemp)
+            XCTAssertEqual(temp.celsius, respTemp)
             exp.fulfill()
         }
         

--- a/Tests/DisruptiveTests/Tests/DeviceTests.swift
+++ b/Tests/DisruptiveTests/Tests/DeviceTests.swift
@@ -153,7 +153,7 @@ class DeviceTests: DisruptiveTests {
         wait(for: [exp], timeout: 1)
     }
     
-    func testGetDevices() {
+    func testGetAllDevices() {
         let reqProjectID = "proj1"
         let reqURL = URL(string: Disruptive.defaultBaseURL)!
             .appendingPathComponent("projects/\(reqProjectID)/devices")
@@ -177,7 +177,7 @@ class DeviceTests: DisruptiveTests {
         }
         
         let exp = expectation(description: "")
-        disruptive.getDevices(projectID: reqProjectID) { result in
+        disruptive.getAllDevices(projectID: reqProjectID) { result in
             switch result {
                 case .success(let devices):
                     XCTAssertEqual(devices, respDevices)

--- a/Tests/DisruptiveTests/Tests/DeviceTests.swift
+++ b/Tests/DisruptiveTests/Tests/DeviceTests.swift
@@ -432,7 +432,7 @@ extension DeviceTests {
             reported = """
             ,"reported": {
                 "temperature": {
-                    "value": \(device.reportedEvents.temperature?.value ?? 0),
+                    "value": \(device.reportedEvents.temperature?.celsius ?? 0),
                     "updateTime": "\(device.reportedEvents.temperature?.timestamp.iso8601String() ?? "-")"
                 }
             }
@@ -470,7 +470,7 @@ extension DeviceTests {
         var reportedEvents = Device.ReportedEvents()
         if isEmulated == false {
             reportedEvents.temperature = TemperatureEvent(
-                value: 56,
+                celsius: 56,
                 timestamp: Date(timeIntervalSince1970: 1605999873)
             )
         }

--- a/Tests/DisruptiveTests/Tests/DeviceTests.swift
+++ b/Tests/DisruptiveTests/Tests/DeviceTests.swift
@@ -189,6 +189,43 @@ class DeviceTests: DisruptiveTests {
         wait(for: [exp], timeout: 1)
     }
     
+    func testGetDevicesPage() {
+        let reqProjectID = "proj1"
+        let reqURL = URL(string: Disruptive.defaultBaseURL)!
+            .appendingPathComponent("projects/\(reqProjectID)/devices")
+        
+        let respDevices = [DeviceTests.createDummyDevice(), DeviceTests.createDummyDevice()]
+        let respData = DeviceTests.createDevicesJSON(from: respDevices, nextPageToken: "nextToken")
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : ["page_size": ["2"], "page_token": ["token"]],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respData, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        disruptive.getDevicesPage(projectID: reqProjectID, pageSize: 2, pageToken: "token") { result in
+            switch result {
+                case .success(let page):
+                    XCTAssertEqual(page.nextPageToken, "nextToken")
+                    XCTAssertEqual(page.devices, respDevices)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+    
     func testUpdateDeviceDisplayName() {
         let reqProjectID = "proj1"
         let reqDeviceID = "dev1"
@@ -454,13 +491,13 @@ extension DeviceTests {
         return createDeviceJSONString(from: device).data(using: .utf8)!
     }
     
-    static func createDevicesJSON(from devices: [Device]) -> Data {
+    static func createDevicesJSON(from devices: [Device], nextPageToken: String = "") -> Data {
         return """
         {
             "devices": [
                 \(devices.map({ createDeviceJSONString(from: $0) }).joined(separator: ","))
             ],
-            "nextPageToken": ""
+            "nextPageToken": "\(nextPageToken)"
         }
         """.data(using: .utf8)!
     }

--- a/Tests/DisruptiveTests/Tests/EmulatorTests.swift
+++ b/Tests/DisruptiveTests/Tests/EmulatorTests.swift
@@ -269,7 +269,7 @@ class EmulatorTests: DisruptiveTests {
         )
         
         assertEvent(
-            event: TemperatureEvent(value: 15, timestamp: now),
+            event: TemperatureEvent(celsius: 15, timestamp: now),
             expectedPayload: """
             {
                 "temperature": {

--- a/Tests/DisruptiveTests/Tests/EventTypesTests.swift
+++ b/Tests/DisruptiveTests/Tests/EventTypesTests.swift
@@ -25,12 +25,12 @@ class EventTypesTests: DisruptiveTests {
         let temp: Float = 25.75
         let event = try! JSONDecoder().decode(TemperatureEvent.self, from: tempEventData(temp: temp))
         XCTAssertEqual(event.timestamp, eventTimestamp)
-        XCTAssertEqual(event.value, temp)
+        XCTAssertEqual(event.celsius, temp)
     }
     
     func testEncodeTempEvent() {
         let temp: Float = 1
-        let event = TemperatureEvent(value: temp, timestamp: eventTimestamp)
+        let event = TemperatureEvent(celsius: temp, timestamp: eventTimestamp)
         let output = try! JSONEncoder().encode(event)
         assertJSONDatasAreEqual(a: output, b: tempEventData(temp: temp))
     }

--- a/Tests/DisruptiveTests/Tests/EventsTests.swift
+++ b/Tests/DisruptiveTests/Tests/EventsTests.swift
@@ -335,7 +335,7 @@ class EventsTests: DisruptiveTests {
     
     func testMergeNothing() {
         var events = Events()
-        events.temperature = [TemperatureEvent(value: 67, timestamp: Date())]
+        events.temperature = [TemperatureEvent(celsius: 67, timestamp: Date())]
         events.merge(with: Events())
         
         XCTAssertNil(events.touch)
@@ -355,7 +355,7 @@ class EventsTests: DisruptiveTests {
     func testMergeSingleEvent() {
         var events = Events()
         var mergee = Events()
-        mergee.temperature = [TemperatureEvent(value: 67, timestamp: Date())]
+        mergee.temperature = [TemperatureEvent(celsius: 67, timestamp: Date())]
         events.merge(with: mergee)
         
         XCTAssertNil(events.touch)
@@ -375,7 +375,7 @@ class EventsTests: DisruptiveTests {
     func testMergeAllEvents() {
         var mergee = Events()
         mergee.touch              = [TouchEvent(timestamp: Date())]
-        mergee.temperature        = [TemperatureEvent(value: 67, timestamp: Date())]
+        mergee.temperature        = [TemperatureEvent(celsius: 67, timestamp: Date())]
         mergee.objectPresent      = [ObjectPresentEvent(state: .objectPresent, timestamp: Date())]
         mergee.humidity           = [HumidityEvent(temperature: 67, relativeHumidity: 90, timestamp: Date())]
         mergee.objectPresentCount = [ObjectPresentCountEvent(total: 67, timestamp: Date())]

--- a/Tests/DisruptiveTests/Tests/EventsTests.swift
+++ b/Tests/DisruptiveTests/Tests/EventsTests.swift
@@ -192,20 +192,6 @@ class EventsTests: DisruptiveTests {
         }
         """.data(using: .utf8)!
         
-        //{
-        //    "eventId": "bjehr0ig1me000dm66s0",
-        //    "targetName": "projects/bhmh0143iktucae701vg/devices/bchonod7rihjtvdmd2vg",
-        //    "eventType": "labelsChanged",
-        //    "data": {
-        //        "added": {},
-        //        "modified": {
-        //            "name": "Sensor name"
-        //        },
-        //        "removed": []
-        //    },
-        //    "timestamp": "2019-05-16T08:21:21.076013Z"
-        //},
-        
         MockURLProtocol.requestHandler = { request in
             self.assertRequestParams(
                 for           : request,
@@ -234,7 +220,6 @@ class EventsTests: DisruptiveTests {
                     XCTAssertNotNil(events.waterPresent)
                     XCTAssertNotNil(events.networkStatus)
                     XCTAssertNotNil(events.batteryStatus)
-//                    XCTAssertNotNil(events.labelsChanged)
                     XCTAssertNotNil(events.connectionStatus)
                     XCTAssertNotNil(events.ethernetStatus)
                     XCTAssertNotNil(events.cellularStatus)

--- a/Tests/DisruptiveTests/Tests/NetworkingTests.swift
+++ b/Tests/DisruptiveTests/Tests/NetworkingTests.swift
@@ -74,7 +74,7 @@ class NetworkingTests: DisruptiveTests {
         }
         
         let exp = expectation(description: "")
-        disruptive.getProjects() { result in
+        disruptive.getAllProjects() { result in
             switch result {
                 case .success(_): XCTFail("Expected failure")
                 case .failure(let err): XCTAssertEqual(err, .serverUnavailable)

--- a/Tests/DisruptiveTests/Tests/NetworkingTests.swift
+++ b/Tests/DisruptiveTests/Tests/NetworkingTests.swift
@@ -10,14 +10,52 @@ import XCTest
 
 class NetworkingTests: DisruptiveTests {
     
-    func testPagedKey() {
-        let fromString = PagedKey(stringValue: "5")
-        XCTAssertEqual(fromString?.intValue, nil)
-        XCTAssertEqual(fromString?.stringValue, "5")
+    func testDecodePagedResult() {
+        struct Dummy: Decodable {
+            let foo: String
+            let bar: Int
+        }
         
-        let fromInt = PagedKey(intValue: 5)
-        XCTAssertEqual(fromInt?.intValue, 5)
-        XCTAssertEqual(fromInt?.stringValue, "5")
+        let validPayload = """
+        {
+            "results": [
+                {
+                    "foo": "some value",
+                    "bar": 42
+                }
+            ],
+            "nextPageToken": "token"
+        }
+        """.data(using: .utf8)!
+        let validOutput = try! JSONDecoder().decode(PagedResult<Dummy>.self, from: validPayload)
+        XCTAssertEqual(validOutput.results.count, 1)
+        XCTAssertEqual(validOutput.results[0].foo, "some value")
+        XCTAssertEqual(validOutput.results[0].bar, 42)
+        XCTAssertEqual(validOutput.nextPageToken, "token")
+        
+        
+        let emptyNextPageTokenPayload = """
+        {
+            "results": [],
+            "nextPageToken": ""
+        }
+        """.data(using: .utf8)!
+        let nextPageTokenOutput = try! JSONDecoder().decode(PagedResult<Dummy>.self, from: emptyNextPageTokenPayload)
+        XCTAssertNil(nextPageTokenOutput.nextPageToken)
+        
+        
+        let invalidPayload = """
+        {
+            "results": [
+                {
+                    "invalid": "some value",
+                    "bar": 42
+                }
+            ],
+            "nextPageToken": "token"
+        }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(PagedResult<Dummy>.self, from: invalidPayload))
     }
     
     func testFormURLEncodedBody() {

--- a/Tests/DisruptiveTests/Tests/PermissionsTests.swift
+++ b/Tests/DisruptiveTests/Tests/PermissionsTests.swift
@@ -50,7 +50,7 @@ class PermissionsTests: DisruptiveTests {
         }
         
         let exp = expectation(description: "")
-        disruptive.getPermissions(forOrganizationID: reqOrgID) { result in
+        disruptive.getPermissions(organizationID: reqOrgID) { result in
             switch result {
                 case .success(let orgs):
                     XCTAssertEqual(orgs, respPermissions)
@@ -86,7 +86,7 @@ class PermissionsTests: DisruptiveTests {
         }
         
         let exp = expectation(description: "")
-        disruptive.getPermissions(forProjectID: reqProjectID) { result in
+        disruptive.getPermissions(projectID: reqProjectID) { result in
             switch result {
                 case .success(let orgs):
                     XCTAssertEqual(orgs, respPermissions)

--- a/Tests/DisruptiveTests/Tests/RequestTests.swift
+++ b/Tests/DisruptiveTests/Tests/RequestTests.swift
@@ -1,0 +1,478 @@
+//
+//  RequestTests.swift
+//  
+//
+//  Created by Vegard Solheim Theriault on 10/01/2021.
+//
+
+import XCTest
+@testable import Disruptive
+
+class RequestTests: DisruptiveTests {
+    func testInitWithoutBody() {
+        let req = Request(
+            method: .get,
+            baseURL: "https://example.com/",
+            endpoint: "endpoint",
+            headers: [HTTPHeader(field: "field", value: "value")],
+            params: ["key": ["value"]]
+        )
+        XCTAssertEqual(req.method, .get)
+        XCTAssertEqual(req.baseURL, "https://example.com/")
+        XCTAssertEqual(req.endpoint, "endpoint")
+        XCTAssertEqual(req.headers[0].field, "field")
+        XCTAssertEqual(req.headers[0].value, "value")
+        XCTAssertEqual(req.params, ["key": ["value"]])
+    }
+    
+    func testInitWithDataBody() {
+        let body = """
+        {
+            "foo": "bar"
+        }
+        """.data(using: .utf8)!
+        
+        do {
+            let req = try Request(method: .post, baseURL: "base", endpoint: "endpoint", body: body)
+            XCTAssertEqual(req.headers.count, 0)
+            XCTAssertEqual(req.body, body)
+        } catch {
+            XCTFail("Shouldn't throw")
+        }
+    }
+    
+    func testInitWithEncodableBody() {
+        struct Payload: Encodable {
+            let foo: String
+        }
+        let body = Payload(foo: "bar")
+        
+        do {
+            let req = try Request(method: .post, baseURL: "base", endpoint: "endpoint", body: body)
+            XCTAssertEqual(req.headers.count, 1)
+            XCTAssertEqual(req.headers[0].field, "Content-Type")
+            XCTAssertEqual(req.headers[0].value, "application/json")
+            XCTAssertEqual(req.body, try! JSONEncoder().encode(body))
+        } catch {
+            XCTFail("Shouldn't throw")
+        }
+    }
+    
+    func testSetHeader() {
+        var req = Request(method: .get, baseURL: "", endpoint: "")
+        XCTAssertEqual(req.headers.count, 0)
+        
+        req.setHeader(field: "foo", value: "bar")
+        XCTAssertEqual(req.headers.count, 1)
+        XCTAssertEqual(req.headers[0].field, "foo")
+        XCTAssertEqual(req.headers[0].value, "bar")
+        
+        req.setHeader(field: "foo", value: "new value")
+        XCTAssertEqual(req.headers.count, 1)
+        XCTAssertEqual(req.headers[0].field, "foo")
+        XCTAssertEqual(req.headers[0].value, "new value")
+        
+        req.setHeader(field: "new key", value: "bar")
+        XCTAssertEqual(req.headers.count, 2)
+        XCTAssertEqual(req.headers[1].field, "new key")
+        XCTAssertEqual(req.headers[1].value, "bar")
+    }
+    
+    func testUrlRequestWithMinimalValues() {
+        let req = Request(method: .get, baseURL: "https://example.com/", endpoint: "ep")
+        let request = req.urlRequest()
+        XCTAssertNotNil(request)
+        XCTAssertEqual(request?.allHTTPHeaderFields, [:])
+        XCTAssertEqual(request?.httpMethod, "GET")
+        XCTAssertNil(request?.httpBody)
+        XCTAssertEqual(request?.url?.absoluteString, "https://example.com/ep")
+    }
+    
+    func testUrlRequestWithAllValues() {
+        let body = """
+        empty
+        """.data(using: .utf8)!
+        
+        do {
+            let req = try Request(
+                method: .delete,
+                baseURL: "https://example.com/",
+                endpoint: "endpoint",
+                headers: [HTTPHeader(field: "first", value: "foo"), HTTPHeader(field: "second", value: "bar")],
+                params: ["foo": ["bar1", "bar2"]],
+                body: body
+            )
+            let request = req.urlRequest()
+            XCTAssertNotNil(request)
+            XCTAssertEqual(request?.allHTTPHeaderFields, ["first": "foo", "second": "bar"])
+            XCTAssertEqual(request?.httpMethod, "DELETE")
+            XCTAssertEqual(request?.httpBody, body)
+            XCTAssertEqual(request?.url?.absoluteString, "https://example.com/endpoint?foo=bar1&foo=bar2")
+        } catch {
+            XCTFail("Shouldn't throw")
+        }
+    }
+    
+    func testUrlRequestInvalidEndpoint() {
+        let req = Request(method: .get, baseURL: "https://example.com/", endpoint: "🙃")
+        XCTAssertNil(req.urlRequest())
+    }
+    
+    func testSendWithNilUrlRequest() {
+        let exp = expectation(description: "")
+        
+        let req = Request(method: .get, baseURL: "", endpoint: "🙃")
+        req.send { (res: Result<String, DisruptiveError>) in
+            XCTAssertEqual(res, .failure(DisruptiveError.unknownError))
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testSendWithKnownError() {
+        let req = Request(method: .get, baseURL: "https://example.com/", endpoint: "ep")
+        let reqURL = req.urlRequest()!.url!
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : false,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 404, httpVersion: nil, headerFields: nil)!
+            return (nil, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        req.send { (result: Result<String, DisruptiveError>) in
+            switch result {
+                case .success          : XCTFail("Unexpected success")
+                case .failure(let err) : XCTAssertEqual(err, .notFound)
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1)
+    }
+    
+    func testSendWithRateLimitError() {
+        let body = """
+        {
+            "updateTime": "\(Date().iso8601String())"
+        }
+        """.data(using: .utf8)!
+        let req = try! Request(method: .get, baseURL: "https://example.com/", endpoint: "ep", body: body)
+        let reqURL = req.urlRequest()!.url!
+        
+        // The request handler will get called two times.
+        // * First time a rate limit of 1 second is returned.
+        // * Second time a 200 is returned
+        var count = 0
+        let retryExpectations = expectation(description: "retry")
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : false,
+                method        : "GET",
+                queryParams   : [:],
+                headers       : [:],
+                url           : reqURL,
+                body          : body
+            )
+            
+            let resp: HTTPURLResponse
+            if count == 0 {
+                // Rate-limit
+                resp = HTTPURLResponse(url: reqURL, statusCode: 429, httpVersion: nil, headerFields: ["Retry-After": "1"])!
+            } else if count == 1 {
+                // Success
+                resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                retryExpectations.fulfill()
+            } else {
+                XCTFail("Should only be called twice")
+                return (nil, nil, nil)
+            }
+            
+            count += 1
+            
+            return (body, resp, nil)
+        }
+        
+        let exp = expectation(description: "success")
+        req.send { (result: Result<TouchEvent, DisruptiveError>) in
+            switch result {
+                case .success: break
+                case .failure(let err) : XCTFail("Err: \(err)")
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [retryExpectations, exp], timeout: 2)
+    }
+    
+    func testSendWithEmptyResponse() {
+        let req = Request(method: .get, baseURL: "https://example.com/", endpoint: "ep")
+        let reqURL = req.urlRequest()!.url!
+
+        MockURLProtocol.requestHandler = { request in
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (nil, resp, nil)
+        }
+
+        let exp = expectation(description: "success")
+        req.send { (result: Result<Request.EmptyResponse, DisruptiveError>) in
+            switch result {
+                case .success: break
+                case .failure(let err) : XCTFail("Err: \(err)")
+            }
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2)
+    }
+    
+    func testSendWithUnparseableResults() {
+        let req = Request(method: .get, baseURL: "https://example.com/", endpoint: "ep")
+        let reqURL = req.urlRequest()!.url!
+        
+        let respBody = """
+        this is not JSON
+        """.data(using: .utf8)
+        
+        MockURLProtocol.requestHandler = { request in
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (respBody, resp, nil)
+        }
+        
+        let exp = expectation(description: "")
+        req.send { (result: Result<TouchEvent, DisruptiveError>) in
+            switch result {
+                case .success          : XCTFail("Unexpected success")
+                case .failure(let err) : XCTAssertEqual(err, .unknownError)
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    func testCheckResponseWithError() {
+        let err = Request.checkResponseForErrors(forRequestURL: "", response: nil, data: nil, error: URLError(.networkConnectionLost))
+        XCTAssertEqual(err, .serverUnavailable)
+    }
+    
+    func testCheckResponseWithoutHTTPResponse() {
+        let err = Request.checkResponseForErrors(forRequestURL: "", response: URLResponse(), data: nil, error: nil)
+        XCTAssertEqual(err, .unknownError)
+    }
+    
+    func testCheckResponseWithVariousInvalidStatusCodes() {
+        func assertError(is expected: InternalError?, forStatusCode code: Int) {
+            let returned = Request.checkResponseForErrors(
+                forRequestURL : "",
+                response      : HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: "2.0", headerFields: nil),
+                data          : nil,
+                error         : nil
+            )
+            XCTAssertEqual(expected, returned)
+        }
+        
+        assertError(is: nil,                             forStatusCode: 200)
+        assertError(is: .badRequest,                     forStatusCode: 400)
+        assertError(is: .unauthorized,                   forStatusCode: 401)
+        assertError(is: .unknownError,                   forStatusCode: 402)
+        assertError(is: .forbidden,                      forStatusCode: 403)
+        assertError(is: .notFound,                       forStatusCode: 404)
+        assertError(is: .conflict,                       forStatusCode: 409)
+        assertError(is: .internalServerError,            forStatusCode: 500)
+        assertError(is: .serviceUnavailable,             forStatusCode: 501)
+        assertError(is: .gatewayTimeout,                 forStatusCode: 503)
+        assertError(is: .tooManyRequests(retryAfter: 5), forStatusCode: 429)
+    }
+    
+    func testCheckResponseWithErrorMessagePayload() {
+        let data = """
+        {
+            "error": "There was an error",
+            "code": 404,
+            "help": "https://d21s.com/help"
+        }
+        """.data(using: .utf8)!
+        let err = Request.checkResponseForErrors(
+            forRequestURL : "",
+            response      : HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 404, httpVersion: "2.0", headerFields: nil),
+            data          : data,
+            error         : nil
+        )
+        XCTAssertEqual(err, .notFound)
+    }
+    
+    func testParsePayloadWithNilPayload() {
+        let str: String? = Request.parsePayload(nil, decoder: JSONDecoder())
+        XCTAssertNil(str)
+    }
+    
+    func testParsePayloadWithUndecodablePayload() {
+        let str: String? = Request.parsePayload("5".data(using: .utf8)!, decoder: JSONDecoder())
+        XCTAssertNil(str)
+    }
+    
+    func testParsePayloadWithValidPayload() {
+        let body = """
+        {
+            "updateTime": "\(Date().iso8601String())"
+        }
+        """.data(using: .utf8)!
+        let event: TouchEvent? = Request.parsePayload(body, decoder: JSONDecoder())
+        XCTAssertNotNil(event)
+    }
+    
+    func testSendRequestSinglePage() {
+        let firstResponse = """
+        {
+            "events": [
+                {
+                    "updateTime": "\(Date().iso8601String())"
+                }
+            ],
+            "nextPageToken": "token"
+        }
+        """.data(using: .utf8)!
+        
+        let secondResponse = """
+        {
+            "events": [
+                {
+                    "updateTime": "\(Date().iso8601String())"
+                }
+            ],
+            "nextPageToken": ""
+        }
+        """.data(using: .utf8)!
+        
+        let req = Request(method: .get, baseURL: "http://example.com", endpoint: "")
+        let reqURL = URL(string: req.baseURL)!
+        
+        var count = 0
+                
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : count == 0 ? ["page_size": ["20"]] : ["page_size": ["30"], "page_token": ["token"]],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            defer { count += 1 }
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            
+            if count == 0 {
+                return (firstResponse, resp, nil)
+            } else {
+                return (secondResponse, resp, nil)
+            }
+        }
+        
+        let firstExp = expectation(description: "")
+        disruptive.sendRequest(req, pageSize: 20, pageToken: nil, pagingKey: "events") { (result: Result<PagedResult<TouchEvent>, DisruptiveError>) in
+            switch result {
+                case .success(let page):
+                    XCTAssertEqual(page.nextPageToken, "token")
+                    XCTAssertEqual(page.results.count, 1)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            firstExp.fulfill()
+        }
+        wait(for: [firstExp], timeout: 1)
+        
+        let secondExp = expectation(description: "")
+        disruptive.sendRequest(req, pageSize: 30, pageToken: "token", pagingKey: "events") { (result: Result<PagedResult<TouchEvent>, DisruptiveError>) in
+            switch result {
+                case .success(let page):
+                    XCTAssertNil(page.nextPageToken)
+                    XCTAssertEqual(page.results.count, 1)
+                case .failure(let err):
+                    XCTFail("Unexpected error: \(err)")
+            }
+            secondExp.fulfill()
+        }
+        wait(for: [secondExp], timeout: 1)
+    }
+    
+    func testSendRequestAllPages() {
+        let firstResponse = """
+        {
+            "events": [
+                {
+                    "updateTime": "\(Date().iso8601String())"
+                }
+            ],
+            "nextPageToken": "token"
+        }
+        """.data(using: .utf8)!
+        
+        let secondResponse = """
+        {
+            "events": [
+                {
+                    "updateTime": "\(Date().iso8601String())"
+                }
+            ],
+            "nextPageToken": ""
+        }
+        """.data(using: .utf8)!
+        
+        let req = Request(method: .get, baseURL: "http://example.com", endpoint: "")
+        let reqURL = URL(string: req.baseURL)!
+        
+        var count = 0
+        
+        MockURLProtocol.requestHandler = { request in
+            self.assertRequestParams(
+                for           : request,
+                authenticated : true,
+                method        : "GET",
+                queryParams   : count == 0 ? [:] : ["page_token": ["token"]],
+                headers       : [:],
+                url           : reqURL,
+                body          : nil
+            )
+            
+            defer {
+                count += 1
+            }
+            
+            let resp = HTTPURLResponse(url: reqURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            
+            if count == 0 {
+                return (firstResponse, resp, nil)
+            } else {
+                return (secondResponse, resp, nil)
+            }
+        }
+        
+        let exp = expectation(description: "")
+        
+        disruptive.sendRequest(req, pagingKey: "events") { (result: Result<[TouchEvent], DisruptiveError>) in
+            switch result {
+                case .success(let events) : XCTAssertEqual(events.count, 2)
+                case .failure(let err)    : XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1)
+    }
+}

--- a/Tests/DisruptiveTests/Tests/RetrySchemeTests.swift
+++ b/Tests/DisruptiveTests/Tests/RetrySchemeTests.swift
@@ -1,0 +1,47 @@
+//
+//  RetrySchemeTests.swift
+//  
+//
+//  Created by Vegard Solheim Theriault on 10/01/2021.
+//
+
+import XCTest
+@testable import Disruptive
+
+class RetrySchemeTests: DisruptiveTests {
+    func testRetryScheme() {
+        var rs = RetryScheme()
+        
+        // Initial
+        XCTAssertEqual(rs.backoffInterval, 0.1)
+        
+        // First increment
+        XCTAssertEqual(rs.nextBackoff(), 0.1)
+        XCTAssertEqual(rs.backoffInterval, 0.1)
+        
+        // Second increment
+        XCTAssertEqual(rs.nextBackoff(), 1)
+        XCTAssertEqual(rs.backoffInterval, 1)
+        
+        // ~Infinite increments
+        for _ in 0..<30 { let _ = rs.nextBackoff() }
+        XCTAssertEqual(rs.nextBackoff(), 15)
+        XCTAssertEqual(rs.backoffInterval, 15)
+        
+        // First reset
+        rs.reset()
+        XCTAssertEqual(rs.backoffInterval, 0.1)
+        
+        // Second reset
+        rs.reset()
+        XCTAssertEqual(rs.backoffInterval, 0.1)
+        
+        // First increment after reset
+        XCTAssertEqual(rs.nextBackoff(), 0.1)
+        XCTAssertEqual(rs.backoffInterval, 0.1)
+        
+        // Second increment after reset
+        XCTAssertEqual(rs.nextBackoff(), 1)
+        XCTAssertEqual(rs.backoffInterval, 1)
+    }
+}


### PR DESCRIPTION
* Added manual pagination (clients can fetch one page at a time)
* Various renamings from eg `getDevices` to `getAllDevices`
* Added `LabelsChangedEvent`
* Fixed bug that prevented device streams from connecting.
* Rename `value` to `celsius` for `Temperature`
* Renamed `AuthProvider` to `Authenticator`
* Improved tests
* Improved documentation